### PR TITLE
Fix deletion of lock error

### DIFF
--- a/modules/CbTarragonPlugLock/connector_lock/connector_lockImpl.cpp
+++ b/modules/CbTarragonPlugLock/connector_lock/connector_lockImpl.cpp
@@ -177,6 +177,7 @@ void connector_lockImpl::handle_unlock() {
         if (this->is_connectorLockFailedUnlock_raised) {
             this->is_connectorLockFailedUnlock_raised = false;
             this->clear_error("connector_lock/ConnectorLockFailedUnlock");
+            this->clear_error("connector_lock/ConnectorLockFailedLock");
         }
         EVLOG_info << "Plug is unlocked. Feedback voltage: " << feedback_voltage << " mV";
         this->assumed_is_locked = false;


### PR DESCRIPTION
This error will only cleared when plug lock is correctly closed again. This can lead to the assumption EVSE is broken.

Since we don't react to cp state changes directly, but to commands comming from EverestManager, the lock error is going to be cleared when the plug lock is in state "unlock". This "unlock" state is essential, because when the plug lock is not in an unlocked state the EVSE can't be used properly.