### PR TITLE
Fix deletion of lock error 2

### DIFF
--- a/modules/CbTarragonPlugLock/connector_lock/connector_lockImpl.cpp
+++ b/modules/CbTarragonPlugLock/connector_lock/connector_lockImpl.cpp
@@ -177,6 +177,9 @@ void connector_lockImpl::handle_unlock() {
         if (this->is_connectorLockFailedUnlock_raised) {
             this->is_connectorLockFailedUnlock_raised = false;
             this->clear_error("connector_lock/ConnectorLockFailedUnlock");
+        }
+        if (this->is_connectorLockFailedLock_raised) {
+            this->is_connectorLockFailedLock_raised = false;
             this->clear_error("connector_lock/ConnectorLockFailedLock");
         }
         EVLOG_info << "Plug is unlocked. Feedback voltage: " << feedback_voltage << " mV";


### PR DESCRIPTION
Unfortunally, there was a copy/paste mistake in the last bugfix. This commit should fix the problem with the error deletion, mentioned in commit a8d63ced30884f2a69d693c406ec5e014944b1ff (refs EVEREST-1000)