### PR TITLE
CMake: add warnings

### DIFF
--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -1,3 +1,7 @@
+add_compile_options(-Wall -Wextra -Werror=switch)
+# generated code has functions often not used
+add_compile_options(-Wno-unused-function)
+
 ev_add_cpp_module(CbTarragonDIs)
 ev_add_cpp_module(CbTarragonDriver)
 ev_add_cpp_module(CbTarragonPlugLock)

--- a/modules/CbSystem/main/systemImpl.cpp
+++ b/modules/CbSystem/main/systemImpl.cpp
@@ -548,6 +548,7 @@ systemImpl::handle_upload_logs(types::system::UploadLogsRequest& upload_logs_req
 
 bool systemImpl::handle_is_reset_allowed(types::system::ResetType& type) {
     // Right now we dont want to reject a reset ever
+    (void)type;
     return true;
 }
 

--- a/modules/CbTarragonDriver/evse_board_support/evse_board_supportImpl.cpp
+++ b/modules/CbTarragonDriver/evse_board_support/evse_board_supportImpl.cpp
@@ -138,6 +138,8 @@ void evse_board_supportImpl::handle_setup(bool& three_phases, bool& has_ventilat
     //        - hw_capabilities.max_phase_count_import is set to '3'
     //        Do we need to make other checks before setting max_phase_count_import and sending it as part of the
     //        hw_capabilties e.g., read out our rotary encoder?
+    (void)country_code;
+
     this->three_phase_supported = three_phases;
 
     if (has_ventilation) {
@@ -209,10 +211,12 @@ void evse_board_supportImpl::handle_allow_power_on(types::evse_board_support::Po
 
 void evse_board_supportImpl::handle_ac_switch_three_phases_while_charging(bool& value) {
     // your code for cmd ac_switch_three_phases_while_charging goes here
+    (void)value;
 }
 
 void evse_board_supportImpl::handle_evse_replug(int& value) {
     // your code for cmd evse_replug goes here
+    (void)value;
 }
 
 types::board_support_common::ProximityPilot evse_board_supportImpl::handle_ac_read_pp_ampacity() {
@@ -329,6 +333,7 @@ void evse_board_supportImpl::pp_observation_worker(void) {
 
 void evse_board_supportImpl::handle_ac_set_overcurrent_limit_A(double& value) {
     // your code for cmd ac_set_overcurrent_limit_A goes here
+    (void)value;
 }
 
 void evse_board_supportImpl::disable_cp_observation(void) {

--- a/modules/CbTarragonDriver/tarragon/CbTarragonCP.cpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonCP.cpp
@@ -16,10 +16,10 @@ CbTarragonCP::CbTarragonCP(const std::string& adc_device_pos_level, const std::s
                            const std::string& peak_detector_reset_gpioline_name_pos_level,
                            const std::string& adc_device_neg_level, const std::string& adc_device_channel_neg_level,
                            const std::string& peak_detector_reset_gpioline_name_neg_level) :
-    peak_detector_reset_time(1500us),
-    valid_signal_delay(2ms),
     pos_adc(adc_device_pos_level, adc_device_channel_pos_level, peak_detector_reset_gpioline_name_pos_level),
-    neg_adc(adc_device_neg_level, adc_device_channel_neg_level, peak_detector_reset_gpioline_name_neg_level) {
+    neg_adc(adc_device_neg_level, adc_device_channel_neg_level, peak_detector_reset_gpioline_name_neg_level),
+    peak_detector_reset_time(1500us),
+    valid_signal_delay(2ms) {
 }
 
 void CbTarragonCP::get_values(int& positive_value, int& negative_value) {


### PR DESCRIPTION
Add warning flags to the modules' compile options via CMake, to assist in development.
Also fix some warnings exposed by these options.

Warnings in generated code are currently to be expected.