### PR TITLE
CbSystem: Add Secure Firmware Update of OCPP 2.0.1 (refs EVEREST-1110)

### DIFF
--- a/modules/CbSystem/diagnostics_uploader.sh
+++ b/modules/CbSystem/diagnostics_uploader.sh
@@ -4,7 +4,7 @@
 
 echo "$UPLOADING"
 sleep 2
-curl --progress-bar --connect-timeout "$CONNECTION_TIMEOUT" -T "${4}" "${2}"
+curl --progress-bar --fail --connect-timeout "$CONNECTION_TIMEOUT" -T "${4}" "${2}"
 curl_exit_code=$?
 if [[ $curl_exit_code -eq 0 ]]; then
     echo "$UPLOADED"

--- a/modules/CbSystem/firmware_updater.sh
+++ b/modules/CbSystem/firmware_updater.sh
@@ -3,7 +3,7 @@
 . "${1}"
 
 echo "$DOWNLOADING"
-curl --progress-bar --connect-timeout "$CONNECTION_TIMEOUT" "${2}" -o "${3}"
+curl --location --progress-bar --fail --connect-timeout "$CONNECTION_TIMEOUT" "${2}" -o "${3}"
 curl_exit_code=$?
 sleep 2
 

--- a/modules/CbSystem/firmware_updater.sh
+++ b/modules/CbSystem/firmware_updater.sh
@@ -31,7 +31,7 @@ marked_good=$(rauc status | grep "boot status" | grep -c good)
 # Check if booted_from and activated are different and the 2 paritions are marked as good
 if [[ "$booted_from" != "$activated" && "$marked_good" -eq 2 ]]; then
 
-    echo "$INSTALLED"
+    echo "$INSTALL_REBOOTING"
 else
     echo "$INSTALLATION_FAILED"
 fi

--- a/modules/CbSystem/main/systemImpl.hpp
+++ b/modules/CbSystem/main/systemImpl.hpp
@@ -69,6 +69,7 @@ private:
     bool standard_firmware_update_running;
     bool firmware_download_running;
     bool firmware_installation_running;
+    types::system::BootReason boot_reason {types::system::BootReason::PowerUp};
 
     std::condition_variable log_upload_cv;
     std::condition_variable firmware_update_cv;
@@ -100,7 +101,6 @@ private:
      */
     types::system::UpdateFirmwareResponse
     handle_standard_firmware_update(const types::system::FirmwareUpdateRequest& firmware_update_request);
-    types::system::UpdateFirmwareResponse
 
     /**
      * @brief Handles the given \p firmware_update_request. If the download should not be started in the future it
@@ -109,6 +109,7 @@ private:
      *
      * @param firmware_update_request
      */
+    types::system::UpdateFirmwareResponse
     handle_signed_fimware_update(const types::system::FirmwareUpdateRequest& firmware_update_request);
 
     /**

--- a/modules/CbSystem/signed_firmware_downloader.sh
+++ b/modules/CbSystem/signed_firmware_downloader.sh
@@ -14,10 +14,9 @@ if [[ $curl_exit_code -eq 0 ]]; then
     echo "$DOWNLOADED"
     echo -e "${4}" >/tmp/signature_validation/firmware_signature.base64
     echo -e "${5}" >/tmp/signature_validation/firmware_cert.pem
-    openssl x509 -pubkey -noout -in /tmp/signature_validation/firmware_cert.pem >/tmp/signature_validation/pubkey.pem
-    openssl base64 -d -in /tmp/signature_validation/firmware_signature.base64 -out /tmp/signature_validation/firmware_signature.sha256
-    r=$(openssl dgst -sha256 -verify /tmp/signature_validation/pubkey.pem -signature /tmp/signature_validation/firmware_signature.sha256 "${3}")
-
+    openssl x509 -pubkey -noout -in /tmp/signature_validation/firmware_cert.pem >/tmp/signature_validation/pubkey.pem # Extract public key from certificate
+    openssl base64 -d -in /tmp/signature_validation/firmware_signature.base64 -out /tmp/signature_validation/firmware_signature.sha256 # Decode base64 signature to binary
+    r=$(openssl dgst -sha256 -verify /tmp/signature_validation/pubkey.pem -signature /tmp/signature_validation/firmware_signature.sha256 -sigopt rsa_padding_mode:pss -sigopt rsa_pss_saltlen:-1 "${3}") # Verify signature
     if [ "$r" = "Verified OK" ]; then
         echo "$SIGNATURE_VERIFIED"
     else

--- a/modules/CbSystem/signed_firmware_downloader.sh
+++ b/modules/CbSystem/signed_firmware_downloader.sh
@@ -7,7 +7,7 @@ sleep 2
 echo "$DOWNLOADING"
 
 sleep 2
-curl --progress-bar --connect-timeout "$CONNECTION_TIMEOUT" "${2}" -o "${3}"
+curl --location --progress-bar --fail --connect-timeout "$CONNECTION_TIMEOUT" "${2}" -o "${3}"
 curl_exit_code=$?
 sleep 2
 if [[ $curl_exit_code -eq 0 ]]; then

--- a/modules/CbSystem/signed_firmware_installer.sh
+++ b/modules/CbSystem/signed_firmware_installer.sh
@@ -4,4 +4,25 @@
 
 echo "$INSTALLING"
 sleep 2
-echo "$INSTALLED"
+
+# Install the firmware image
+rauc install "${2}" >/dev/null 2>&1
+
+# Get the output of "rauc status" command
+status_output=$(rauc status)
+
+# Get the line containing "Booted from" and extract the value after the colon
+booted_from=$(echo "$status_output" | grep "Booted from" | awk -F ': ' '{print $2}')
+
+# Get the line containing "Activated" and extract the value after the colon
+activated=$(echo "$status_output" | grep "Activated" | awk -F ': ' '{print $2}')
+
+# Get the number of partitions marked as good
+marked_good=$(echo "$status_output" | grep "boot status" | grep -c good)
+
+# Check if booted_from and activated are different and the 2 partitions are marked as good
+if [[ "$booted_from" != "$activated" && "$marked_good" -eq 2 ]]; then
+    echo "$INSTALL_REBOOTING"
+else
+    echo "$INSTALLATION_FAILED"
+fi


### PR DESCRIPTION
CbSystem: Add Secure Firmware Update of OCPP 2.0.1 (refs EVEREST-1110)

Now the charging station sends a FirmwareStatusNotificationRequest with
status "Installed" after rebooting of the board for the secured and common
firmware update mechanism. Before rebooting the board, the charging
station sends a FirmwareStatusNotificationRequest with status "InstallRebooting".
Added a flag in "/var/lib/everest/.ocpp_fw_installed" to detect that the
firmware has been successfully installed after rebooting the board.


CbSystem: Improve curl command to download/upload files (refs EVEREST-1110)

The curl command to download/upload files was improved to use the --fail option
to stop the script if the download fails. The --location option was added
to follow redirects.