### PR TITLE
Fix FirmwareStatusNotificationRequest(status = Installed) (refs EVEREST-1175)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14.7)
 
-project(everest-chargebyte VERSION 0.13.0
+project(everest-chargebyte VERSION 0.14.0
     DESCRIPTION "chargebyte's Hardware EVerest Modules"
     LANGUAGES CXX)
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository includes the following modules:
 ## Compatibility matrix
 | Tag | EVerest release |
 |----------|----------|
+| 0.14.0 | 2024.7.0 |
 | 0.13.0 | 2024.7.0 |
 | 0.12.0 | 2024.5.0 |
 | 0.11.0 | 2024.5.0 |

--- a/modules/CbSystem/main/systemImpl.cpp
+++ b/modules/CbSystem/main/systemImpl.cpp
@@ -142,7 +142,10 @@ static std::string get_partition(PartitionType part_type) {
 }
 
 void systemImpl::ready() {
+    check_update_marker();
+}
 
+void systemImpl::check_update_marker() {
     // In case the firmware-update marker file exists, we need to check if the firmware update was successful
     // and publish the status.
     if (fs::exists(MARKER_FILE_PATH)) {
@@ -159,7 +162,7 @@ void systemImpl::ready() {
         if (partition == get_partition(PartitionType::Active)) {
             this->publish_firmware_update_status(
                 {types::system::FirmwareUpdateStatusEnum::Installed, std::stoi(request_id)});
-            EVLOG_info << "Firmware update was successful";
+            EVLOG_info << "Firmware update was successful (id: " << request_id << ")";
         } else {
             this->publish_firmware_update_status(
                 {types::system::FirmwareUpdateStatusEnum::InstallationFailed, std::stoi(request_id)});

--- a/modules/CbSystem/main/systemImpl.cpp
+++ b/modules/CbSystem/main/systemImpl.cpp
@@ -142,6 +142,9 @@ static std::string get_partition(PartitionType part_type) {
 }
 
 void systemImpl::ready() {
+    // TODO: Remove this sleep when fix of the issues (ref: https://github.com/EVerest/libocpp/issues/758,
+    // https://github.com/EVerest/everest-core/issues/841) are implemented
+    sleep(20);
     check_update_marker();
 }
 

--- a/modules/CbSystem/main/systemImpl.hpp
+++ b/modules/CbSystem/main/systemImpl.hpp
@@ -138,6 +138,8 @@ private:
      */
     void install_signed_firmware(const types::system::FirmwareUpdateRequest& firmware_update_reqeust,
                                  const std::filesystem::path& firmware_file_path);
+
+    void check_update_marker();
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
 };
 

--- a/modules/CbSystem/main/systemImpl.hpp
+++ b/modules/CbSystem/main/systemImpl.hpp
@@ -139,6 +139,10 @@ private:
     void install_signed_firmware(const types::system::FirmwareUpdateRequest& firmware_update_reqeust,
                                  const std::filesystem::path& firmware_file_path);
 
+    /**
+     *  @brief Checks if the firmware update marker is present and if so, 
+     *  notify the upper layer that the firmware update was successfuly installed.
+     */
     void check_update_marker();
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
 };


### PR DESCRIPTION
The variable to publish FirmwareStatusNotification::Installed message is
now delayed, because the message is dropped in case the OCPP client is
not connected or the OCPP module is not yet subscribed to the variable.
This is only a temporary solution to  pass TC_L_01 OCPP 2.0.1 test case
and should be removed as soon as a proper fixes are implemented in
the reported issues (https://github.com/EVerest/libocpp/issues/758,
https://github.com/EVerest/everest-core/issues/841).