### PR TITLE
CbSystem: publish LogStatus `AcceptedCanceled`, adapt to changed system interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ This repository includes the following modules:
 ## Compatibility matrix
 | Tag | EVerest release |
 |----------|----------|
-| 0.14.0 | 2024.7.0 |
-| 0.13.0 | 2024.7.0 |
-| 0.12.0 | 2024.5.0 |
-| 0.11.0 | 2024.5.0 |
-| 0.10.0 | 2024.5.0 |
-| 0.9.0 | 2024.3.0 |
+| 0.14.0 | 2024.8.0 |
+| 0.13.0 | 2024.7.1 <br> 2024.7.0 |
+| 0.12.0 | 2024.6.0 <br> 2024.5.0 |
+| 0.11.0 | 2024.6.0 <br> 2024.5.0 |
+| 0.10.0 | 2024.6.0 <br> 2024.5.0 |
+| 0.9.0  | 2024.3.0 |
 
 ## Usage
 To build and use these modules in EVerest, check out this repository in the same directory as everest-core, i.e., your EVerest workspace.

--- a/modules/CbSystem/main/systemImpl.cpp
+++ b/modules/CbSystem/main/systemImpl.cpp
@@ -313,7 +313,7 @@ systemImpl::handle_signed_fimware_update(const types::system::FirmwareUpdateRequ
     }
 
     if (this->firmware_download_running) {
-        return types::system::UpdateFirmwareResponse::AcceptedCancelled;
+        return types::system::UpdateFirmwareResponse::AcceptedCanceled;
     } else if (this->firmware_installation_running) {
         return types::system::UpdateFirmwareResponse::Rejected;
     } else {
@@ -570,7 +570,7 @@ systemImpl::handle_upload_logs(types::system::UploadLogsRequest& upload_logs_req
     types::system::UploadLogsResponse response;
 
     if (this->log_upload_running) {
-        response.upload_logs_status = types::system::UploadLogsStatus::AcceptedCancelled;
+        response.upload_logs_status = types::system::UploadLogsStatus::AcceptedCanceled;
     } else {
         response.upload_logs_status = types::system::UploadLogsStatus::Accepted;
     }
@@ -643,9 +643,8 @@ systemImpl::handle_upload_logs(types::system::UploadLogsRequest& upload_logs_req
                 EVLOG_info << "Uploading Logs was interrupted, terminating upload script, requestId: "
                            << log_status.request_id;
                 // N01.FR.20
-                // FIXME: This enum is not yet implemented upstream. When it is, activate this code:
-                // log_status.log_status = types::system::LogStatusEnum::AcceptedCanceled;
-                // this->publish_log_status(log_status);
+                log_status.log_status = types::system::LogStatusEnum::AcceptedCanceled;
+                this->publish_log_status(log_status);
                 cmd.terminate();
             } else if (log_status.log_status != types::system::LogStatusEnum::Uploaded && retries <= total_retries) {
                 // command finished, but neither interrupted nor uploaded


### PR DESCRIPTION
This adapts CbSystem to the changes made to the enums in EVerest release 2024.8.0 (from everest-core PR
https://github.com/EVerest/everest-core/pull/826).

CbSystem now publishes the correct LogStatus `AcceptedCanceled`, an enum which was previously missing.