### PR TITLE
Fix example config for error_history interface

### DIFF
--- a/config/bsp-only.yaml
+++ b/config/bsp-only.yaml
@@ -7,8 +7,8 @@ active_modules:
     module: API
     connections:
       evse_manager:
-      - module_id: connector
-        implementation_id: evse
+        - module_id: connector
+          implementation_id: evse
       error_history:
         - module_id: error_history
           implementation_id: error_history
@@ -33,8 +33,8 @@ active_modules:
     module: EnergyManager
     connections:
       energy_trunk:
-      - module_id: grid_connection_point
-        implementation_id: energy_grid
+        - module_id: grid_connection_point
+          implementation_id: energy_grid
   grid_connection_point:
     module: EnergyNode
     config_module:
@@ -42,8 +42,8 @@ active_modules:
       phase_count: 3
     connections:
       energy_consumer:
-      - module_id: connector
-        implementation_id: energy_grid
+        - module_id: connector
+          implementation_id: energy_grid
   error_history:
     module: ErrorHistory
     config_implementation:

--- a/config/bsp-only.yaml
+++ b/config/bsp-only.yaml
@@ -9,6 +9,9 @@ active_modules:
       evse_manager:
       - module_id: connector
         implementation_id: evse
+      error_history:
+        - module_id: error_history
+          implementation_id: error_history
   tarragon_bsp:
     module: CbTarragonDriver
     config_module:
@@ -41,3 +44,8 @@ active_modules:
       energy_consumer:
       - module_id: connector
         implementation_id: energy_grid
+  error_history:
+    module: ErrorHistory
+    config_implementation:
+      error_history:
+        database_path: /tmp/error_history.db


### PR DESCRIPTION
EVerest release 2024.7.0 added a provider of the `error_history` interface as a mandatory requirement to the API module, in commit https://github.com/EVerest/everest-core/commit/2452ed711d2cd91137ac1f756e35bb0e1bc90dcd.

While this requirement will be made optional in the next release after 2024.8.0 (see commit https://github.com/EVerest/everest-core/commit/940c920129ad2a25360e484dcf0a3e9f3daa1b88), and our own images will try to make this requirement optional, the provided configs should be made to work for all users of our repository.