### PR TITLE
CbChargeSOM: add fake contactor handling and cleanup

### DIFF
--- a/modules/CbChargeSOMDriver/evse_board_support/evse_board_supportImpl.cpp
+++ b/modules/CbChargeSOMDriver/evse_board_support/evse_board_supportImpl.cpp
@@ -53,8 +53,6 @@ void evse_board_supportImpl::init() {
 void evse_board_supportImpl::ready() {
     // the BSP must publish this variable at least once during start up
     this->publish_capabilities(this->hw_capabilities);
-    // here too, hard-coded 3 phases for the moment
-    this->publish_ac_nr_of_phases_available(3);
 }
 
 void evse_board_supportImpl::update_cp_state_internally(types::cb_board_support::CPState state,

--- a/modules/CbChargeSOMDriver/evse_board_support/evse_board_supportImpl.cpp
+++ b/modules/CbChargeSOMDriver/evse_board_support/evse_board_supportImpl.cpp
@@ -133,6 +133,13 @@ void evse_board_supportImpl::handle_allow_power_on(types::evse_board_support::Po
     do {
         try {
             this->mod->controller.set_allow_power_on(value.allow_power_on);
+
+            types::board_support_common::Event tmp_event = value.allow_power_on
+                                                               ? types::board_support_common::Event::PowerOn
+                                                               : types::board_support_common::Event::PowerOff;
+            types::board_support_common::BspEvent tmp {tmp_event};
+            this->publish_event(tmp);
+
             break;
         } catch (std::system_error& e) {
             EVLOG_error << e.what();


### PR DESCRIPTION
This small PR add a very simple contactor faking and cleans up a not required initialization.
