### PR TITLE
CbTarragonDriver: initial support for phase-count switching

### DIFF
--- a/modules/CbTarragonDriver/CbTarragonDriver.hpp
+++ b/modules/CbTarragonDriver/CbTarragonDriver.hpp
@@ -24,6 +24,7 @@ struct Conf {
     std::string connector_type;
     std::string contactor_1_feedback_type;
     std::string contactor_2_feedback_type;
+    std::string switch_3ph1ph_wiring;
     std::string relay_1_name;
     std::string relay_1_actuator_gpio_line_name;
     std::string relay_1_feedback_gpio_line_name;

--- a/modules/CbTarragonDriver/CbTarragonDriver.hpp
+++ b/modules/CbTarragonDriver/CbTarragonDriver.hpp
@@ -22,6 +22,8 @@ namespace module {
 
 struct Conf {
     std::string connector_type;
+    double min_current_A;
+    double max_current_A;
     std::string contactor_1_feedback_type;
     std::string contactor_2_feedback_type;
     std::string switch_3ph1ph_wiring;

--- a/modules/CbTarragonDriver/CbTarragonDriver.hpp
+++ b/modules/CbTarragonDriver/CbTarragonDriver.hpp
@@ -27,9 +27,11 @@ struct Conf {
     std::string relay_1_name;
     std::string relay_1_actuator_gpio_line_name;
     std::string relay_1_feedback_gpio_line_name;
+    int relay_1_feedback_gpio_debounce_us;
     std::string relay_2_name;
     std::string relay_2_actuator_gpio_line_name;
     std::string relay_2_feedback_gpio_line_name;
+    int relay_2_feedback_gpio_debounce_us;
     std::string cp_rst_neg_peak_gpio_line_name;
     std::string cp_neg_peak_adc_device;
     std::string cp_neg_peak_adc_channel;

--- a/modules/CbTarragonDriver/evse_board_support/evse_board_supportImpl.cpp
+++ b/modules/CbTarragonDriver/evse_board_support/evse_board_supportImpl.cpp
@@ -489,7 +489,7 @@ void evse_board_supportImpl::contactor_handling_worker(void) {
             if (this->contactor_controller.is_error_state()) {
                 this->contactor_controller.set_actual_state(
                     this->contactor_controller.get_state(StateType::TARGET_STATE));
-                EVLOG_info << "Contactor state: " << this->contactor_controller.get_state(StateType::TARGET_STATE);
+                EVLOG_info << "Contactor state: " << this->contactor_controller;
 
                 // publish PowerOn or PowerOff event
                 types::board_support_common::Event tmp_event =
@@ -515,7 +515,7 @@ void evse_board_supportImpl::contactor_handling_worker(void) {
                 contactor_state != this->contactor_controller.get_state(StateType::ACTUAL_STATE)) {
                 // if the received state is equal to the expected state, set the actual state
                 this->contactor_controller.set_actual_state(contactor_state);
-                EVLOG_info << "Contactor state: " << this->contactor_controller.get_state(StateType::TARGET_STATE);
+                EVLOG_info << "Contactor state: " << this->contactor_controller;
 
                 // publish PowerOn or PowerOff event
                 types::board_support_common::Event tmp_event = (contactor_state == ContactorState::CONTACTOR_CLOSED)

--- a/modules/CbTarragonDriver/evse_board_support/evse_board_supportImpl.cpp
+++ b/modules/CbTarragonDriver/evse_board_support/evse_board_supportImpl.cpp
@@ -73,9 +73,10 @@ void evse_board_supportImpl::init() {
     // Relay and contactor handling
     this->contactor_controller = CbTarragonContactorControl(
         this->mod->config.relay_1_name, this->mod->config.relay_1_actuator_gpio_line_name,
-        this->mod->config.relay_1_feedback_gpio_line_name, this->mod->config.contactor_1_feedback_type,
-        this->mod->config.relay_2_name, this->mod->config.relay_2_actuator_gpio_line_name,
-        this->mod->config.relay_2_feedback_gpio_line_name, this->mod->config.contactor_2_feedback_type);
+        this->mod->config.relay_1_feedback_gpio_line_name, this->mod->config.relay_1_feedback_gpio_debounce_us,
+        this->mod->config.contactor_1_feedback_type, this->mod->config.relay_2_name,
+        this->mod->config.relay_2_actuator_gpio_line_name, this->mod->config.relay_2_feedback_gpio_line_name,
+        this->mod->config.relay_2_feedback_gpio_debounce_us, this->mod->config.contactor_2_feedback_type);
 
     // set the contactor handling related flags and timeout
     this->contactor_feedback_timeout = 200ms;

--- a/modules/CbTarragonDriver/evse_board_support/evse_board_supportImpl.cpp
+++ b/modules/CbTarragonDriver/evse_board_support/evse_board_supportImpl.cpp
@@ -37,11 +37,13 @@ void evse_board_supportImpl::init() {
     this->termination_requested = false;
     this->pp_fault_reported = false;
 
-    // configure hardware capabilities
-    this->hw_capabilities.max_current_A_import = 32;
-    this->hw_capabilities.min_current_A_import = 6;
-    this->hw_capabilities.max_current_A_export = 32;
-    this->hw_capabilities.min_current_A_export = 6;
+    // configure hardware capabilities: use user-configurable settings for flexibility
+    // but use the same value for import and export - there seems to be no reason for AC
+    // that these values differ for import and export
+    this->hw_capabilities.min_current_A_import = this->mod->config.min_current_A;
+    this->hw_capabilities.max_current_A_import = this->mod->config.max_current_A;
+    this->hw_capabilities.min_current_A_export = this->mod->config.min_current_A;
+    this->hw_capabilities.max_current_A_export = this->mod->config.max_current_A;
 
     // check whether the configuration allows to enable phase-count switching support:
     // - 'switch_3ph1ph_wiring' must not be 'none'

--- a/modules/CbTarragonDriver/manifest.yaml
+++ b/modules/CbTarragonDriver/manifest.yaml
@@ -44,6 +44,12 @@ config:
       The GPIO line name to which the feedback/sense signal is connected to
     type: string
     default: RELAY_1_SENSE
+  relay_1_feedback_gpio_debounce_us:
+    description: >-
+      The debounce period in microseconds which should be configured for the GPIO.
+      Use zero to skip any debounce period configuration.
+    type: integer
+    default: 10000
   relay_2_name:
     description:  >-
       Name of the second relay and its feedback as labeled on hardware. This relay is
@@ -60,6 +66,12 @@ config:
       The GPIO line name to which the feedback/sense signal is connected to
     type: string
     default: RELAY_2_SENSE
+  relay_2_feedback_gpio_debounce_us:
+    description: >-
+      The debounce period in microseconds which should be configured for the GPIO.
+      Use zero to skip any debounce period configuration.
+    type: integer
+    default: 10000
   cp_rst_neg_peak_gpio_line_name:
     description: The GPIO line name of reset pin for negative peak ADC
     type: string

--- a/modules/CbTarragonDriver/manifest.yaml
+++ b/modules/CbTarragonDriver/manifest.yaml
@@ -7,6 +7,14 @@ config:
       - IEC62196Type2Cable
       - IEC62196Type2Socket
     default: IEC62196Type2Socket
+  min_current_A:
+    description: The minimum current in ampere which can be imported/exported.
+    type: number
+    default: 6
+  max_current_A:
+    description: The maximum current in ampere which can be imported/exported.
+    type: number
+    default: 80
   contactor_1_feedback_type:
     description: >-
       Defines the logic behind the feedback

--- a/modules/CbTarragonDriver/manifest.yaml
+++ b/modules/CbTarragonDriver/manifest.yaml
@@ -8,11 +8,18 @@ config:
       - IEC62196Type2Socket
     default: IEC62196Type2Socket
   min_current_A:
-    description: The minimum current in ampere which can be imported/exported.
+    description: >-
+      The minimum current in ampere which can be imported/exported. The default value
+      of 6 A corresponds to the lowest value which is technically possible to signal
+      by the IEC 61851 standard via PWM.
     type: number
     default: 6
   max_current_A:
-    description: The maximum current in ampere which can be imported/exported.
+    description: >-
+      The maximum current in ampere which can be imported/exported. Here too,
+      the default corresponds to the maximum value which is possible to signal
+      with the IEC 61851 standard. The value should be adjusted if there is no
+      other limitating value/instance which represents the physical charger limits.
     type: number
     default: 80
   contactor_1_feedback_type:
@@ -49,7 +56,7 @@ config:
       In 'serial' setups, the secondary contactor is closed before the primary
       contactor, and the primary contactor is opened before the secondary one.
       This ensures that the desired phases are offered to the vehicle at the same time.
-      In 'mutual' setups, the primary contactor switch all available phases while the
+      In 'mutual' setups, the primary contactor switches all available phases while the
       secondary contactor only switches a single phase. Both contactors are wired
       parallel, so that only exactly one contactor must be switched on at the same time.
       See user guide for wiring schematics and details.
@@ -74,7 +81,7 @@ config:
     default: RELAY_1_SENSE
   relay_1_feedback_gpio_debounce_us:
     description: >-
-      The debounce period in microseconds which should be configured for the GPIO.
+      The debounce period in microseconds which should be configured for the feedback GPIO.
       Use zero to skip any debounce period configuration.
     type: integer
     default: 10000
@@ -93,7 +100,7 @@ config:
     default: RELAY_2_SENSE
   relay_2_feedback_gpio_debounce_us:
     description: >-
-      The debounce period in microseconds which should be configured for the GPIO.
+      The debounce period in microseconds which should be configured for the feedback GPIO.
       Use zero to skip any debounce period configuration.
     type: integer
     default: 10000

--- a/modules/CbTarragonDriver/manifest.yaml
+++ b/modules/CbTarragonDriver/manifest.yaml
@@ -31,8 +31,28 @@ config:
       - no
       - nc
     default: none
+  switch_3ph1ph_wiring:
+    description: >-
+      Tells the implementation which wiring configuration for phase-count
+      switching is used:
+      - 'none': no phase-count switching setup
+      - 'serial': the secondary contactor is wired in series to the primary contactor
+      - 'mutual': the secondary contactor is wired in parallel to the primary contactor
+      In 'serial' setups, the secondary contactor is closed before the primary
+      contactor, and the primary contactor is opened before the secondary one.
+      This ensures that the desired phases are offered to the vehicle at the same time.
+      In 'mutual' setups, the primary contactor switch all available phases while the
+      secondary contactor only switches a single phase. Both contactors are wired
+      parallel, so that only exactly one contactor must be switched on at the same time.
+      See user guide for wiring schematics and details.
+    type: string
+    enum:
+      - none
+      - serial
+      - mutual
+    default: none
   relay_1_name:
-    description: Name of the first the relay and its feedback as labeled on hardware
+    description: Name of the first relay and its feedback as labeled on hardware
     type: string
     default: R1/S1
   relay_1_actuator_gpio_line_name:
@@ -40,7 +60,7 @@ config:
     type: string
     default: RELAY_1_ENABLE
   relay_1_feedback_gpio_line_name:
-    description:  >-
+    description: >-
       The GPIO line name to which the feedback/sense signal is connected to
     type: string
     default: RELAY_1_SENSE
@@ -51,10 +71,7 @@ config:
     type: integer
     default: 10000
   relay_2_name:
-    description:  >-
-      Name of the second relay and its feedback as labeled on hardware. This relay is
-      normally used for 3-phase operation. If this relay should be used for other
-      purposes other than 3-phase operation, set the name to "none".
+    description: Name of the second relay and its feedback as labeled on hardware
     type: string
     default: R2/S2
   relay_2_actuator_gpio_line_name:

--- a/modules/CbTarragonDriver/tarragon/CbTarragonContactorControl.cpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonContactorControl.cpp
@@ -13,10 +13,12 @@ CbTarragonContactorControl::CbTarragonContactorControl(void) {
 
 CbTarragonContactorControl::CbTarragonContactorControl(
     const std::string& relay_1_name, const std::string& relay_1_actuator_gpio_line_name,
-    const std::string& relay_1_feedback_gpio_line_name, const std::string& contactor_1_feedback_type,
-    const std::string& relay_2_name, const std::string& relay_2_actuator_gpio_line_name,
-    const std::string& relay_2_feedback_gpio_line_name, const std::string& contactor_2_feedback_type) :
-    relay_1(relay_1_name, relay_1_actuator_gpio_line_name, contactor_1_feedback_type, relay_1_feedback_gpio_line_name),
+    const std::string& relay_1_feedback_gpio_line_name, const unsigned int relay_1_gpio_debounce_us,
+    const std::string& contactor_1_feedback_type, const std::string& relay_2_name,
+    const std::string& relay_2_actuator_gpio_line_name, const std::string& relay_2_feedback_gpio_line_name,
+    const unsigned int relay_2_gpio_debounce_us, const std::string& contactor_2_feedback_type) :
+    relay_1(relay_1_name, relay_1_actuator_gpio_line_name, contactor_1_feedback_type, relay_1_feedback_gpio_line_name,
+            relay_1_gpio_debounce_us),
     contactor_1_feedback_type(contactor_1_feedback_type) {
 
     EVLOG_info << "Primary contactor feedback type: '" << this->contactor_1_feedback_type << "'";
@@ -30,7 +32,7 @@ CbTarragonContactorControl::CbTarragonContactorControl(
     // software that utilizes the relay to its need.
     if (relay_2_name == "R2/S2") {
         this->relay_2 = CbTarragonRelay(relay_2_name, relay_2_actuator_gpio_line_name, contactor_2_feedback_type,
-                                        relay_2_feedback_gpio_line_name);
+                                        relay_2_feedback_gpio_line_name, relay_2_gpio_debounce_us);
 
         this->contactor_2_feedback_type = contactor_2_feedback_type;
         EVLOG_info << "Secondary contactor feedback type: '" << this->contactor_2_feedback_type << "'";

--- a/modules/CbTarragonDriver/tarragon/CbTarragonContactorControl.cpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonContactorControl.cpp
@@ -82,7 +82,7 @@ ContactorState CbTarragonContactorControl::get_current_state() {
                : ContactorState::CONTACTOR_OPEN;
 }
 
-ContactorState CbTarragonContactorControl::get_state(StateType state) {
+ContactorState CbTarragonContactorControl::get_state(StateType state) const {
     if (state == StateType::ACTUAL_STATE)
         return this->actual_state;
     else if (state == StateType::TARGET_STATE)
@@ -168,7 +168,7 @@ void CbTarragonContactorControl::set_actual_state(ContactorState actual_state) {
     }
 }
 
-void CbTarragonContactorControl::update_actual_phase_count(void) {
+void CbTarragonContactorControl::update_actual_phase_count() {
     bool relay_1_feedback_state = this->relay_1.get_feedback_state();
     bool relay_2_feedback_state = this->relay_2.has_value() ? this->relay_2.value().get_feedback_state() : false;
 
@@ -182,11 +182,11 @@ void CbTarragonContactorControl::update_actual_phase_count(void) {
         this->actual_phase_count = 3;
 }
 
-int CbTarragonContactorControl::get_actual_phase_count(void) {
+int CbTarragonContactorControl::get_actual_phase_count() const {
     return this->actual_phase_count;
 }
 
-int CbTarragonContactorControl::get_target_phase_count(void) {
+int CbTarragonContactorControl::get_target_phase_count() const {
     return this->target_phase_count;
 }
 
@@ -197,23 +197,23 @@ void CbTarragonContactorControl::switch_phase_count(bool use_3phases) {
         this->target_phase_count = 1;
 }
 
-std::chrono::time_point<std::chrono::steady_clock> CbTarragonContactorControl::get_new_target_state_ts(void) {
+std::chrono::time_point<std::chrono::steady_clock> CbTarragonContactorControl::get_new_target_state_ts() const {
     return this->new_target_state_ts;
 }
 
-bool CbTarragonContactorControl::get_is_new_target_state_set(void) {
+bool CbTarragonContactorControl::get_is_new_target_state_set() const {
     return this->is_new_target_state_set;
 }
 
-void CbTarragonContactorControl::reset_is_new_target_state_set(void) {
+void CbTarragonContactorControl::reset_is_new_target_state_set() {
     this->is_new_target_state_set = false;
 }
 
-std::chrono::time_point<std::chrono::steady_clock> CbTarragonContactorControl::get_last_actual_state_open_ts(void) {
+std::chrono::time_point<std::chrono::steady_clock> CbTarragonContactorControl::get_last_actual_state_open_ts() const {
     return this->last_actual_state_open_ts;
 }
 
-bool CbTarragonContactorControl::is_switch_on_allowed(void) {
+bool CbTarragonContactorControl::is_switch_on_allowed() {
     bool allowed {true};
 
     // avoid very fast switching in order to ensure internal relay lifetime
@@ -227,15 +227,15 @@ bool CbTarragonContactorControl::is_switch_on_allowed(void) {
     return allowed;
 }
 
-bool CbTarragonContactorControl::get_delay_contactor_close(void) {
+bool CbTarragonContactorControl::get_delay_contactor_close() const {
     return this->delay_contactor_close;
 }
 
-void CbTarragonContactorControl::reset_delay_contactor_close(void) {
+void CbTarragonContactorControl::reset_delay_contactor_close() {
     this->delay_contactor_close = false;
 }
 
-bool CbTarragonContactorControl::is_error_state(void) {
+bool CbTarragonContactorControl::is_error_state() const {
     if (this->actual_state != this->target_state)
         return true;
 
@@ -263,7 +263,7 @@ bool CbTarragonContactorControl::wait_for_events(std::chrono::milliseconds durat
     return event_occurred;
 }
 
-bool CbTarragonContactorControl::read_events(void) {
+bool CbTarragonContactorControl::read_events() {
     gpiod::edge_event::event_type event;
     bool contactor_state = 0;
 
@@ -287,20 +287,26 @@ bool CbTarragonContactorControl::read_events(void) {
 }
 
 std::ostream& operator<<(std::ostream& os, const ContactorState& state) {
-    std::string mapped_state;
-
     switch (state) {
     case ContactorState::CONTACTOR_CLOSED:
-        mapped_state = "CLOSED";
+        os << "CLOSED";
         break;
     case ContactorState::CONTACTOR_OPEN:
-        mapped_state = "OPEN";
+        os << "OPEN";
         break;
     default:
-        mapped_state = "UNKNOWN";
+        os << "UNKNOWN";
         break;
     }
+    return os;
+}
 
-    os << mapped_state;
+std::ostream& operator<<(std::ostream& os, const CbTarragonContactorControl& cc) {
+    ContactorState state{cc.get_state(StateType::ACTUAL_STATE)};
+
+    os << state;
+    if (state == ContactorState::CONTACTOR_CLOSED)
+        os << " (phases: " << cc.get_actual_phase_count() << ")";
+
     return os;
 }

--- a/modules/CbTarragonDriver/tarragon/CbTarragonContactorControl.cpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonContactorControl.cpp
@@ -41,7 +41,7 @@ CbTarragonContactorControl::CbTarragonContactorControl(
             EVLOG_warning << "The secondary contactor has the feedback pin not connected. This is not recommended.";
     }
 
-    // if phase-count switching is enable, we default to 3-phase operation
+    // if phase-count switching is enabled, we default to 3-phase operation
     this->target_phase_count = switch_3ph1ph_enabled ? 3 : 1;
 
     // initialize the actual state by reading the GPIO feedback
@@ -73,7 +73,7 @@ ContactorState CbTarragonContactorControl::get_current_state() {
     }
 
     // reaching this line means: phase-count switching setup
-    // so not having the second relay configured is error -> report us UNKNOWN
+    // so not having the second relay configured is error -> report as UNKNOWN
     if (!this->relay_2.has_value())
         return ContactorState::CONTACTOR_UNKNOWN;
 

--- a/modules/CbTarragonDriver/tarragon/CbTarragonContactorControl.hpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonContactorControl.hpp
@@ -75,7 +75,7 @@ public:
                                const std::string& contactor_2_feedback_type, bool switch_3ph1ph_enabled);
 
     /// @brief Get the state of one or both contactors ('actual' or 'target').
-    ContactorState get_state(StateType state);
+    ContactorState get_state(StateType state) const;
 
     /// @brief Set the target state of one or both contactors.
     /// @param target_state The desired contactor state (OPEN or CLOSED).
@@ -86,48 +86,48 @@ public:
     void set_actual_state(ContactorState actual_state);
 
     /// @brief Update the number of phases in operation.
-    void update_actual_phase_count(void);
+    void update_actual_phase_count();
 
     /// @brief Get the number of phases in operation.
     /// @return number of phases
     ///         (0 = Error: no phases in operation, 1 = 1-phase, 3 = 3-phase).
-    int get_actual_phase_count(void);
+    int get_actual_phase_count() const;
 
     /// @brief Get the target number of phases.
     /// @return number of phases
     ///         (1 = 1-phase, 3 = 3-phase).
-    int get_target_phase_count(void);
+    int get_target_phase_count() const;
 
     /// @brief Switch between 3-phase and 1-phase operation mode.
     /// @param use_3phases True if 3 phases shall be used, false otherwise.
     void switch_phase_count(bool use_3phases);
 
     /// @brief Return the timestamp at which a new state was set to the actuator
-    std::chrono::time_point<std::chrono::steady_clock> get_new_target_state_ts(void);
+    std::chrono::time_point<std::chrono::steady_clock> get_new_target_state_ts() const;
 
     /// @brief Return the status of the flag marking the start of observation
     ///        of the timestamp at which a new state was set to the actuator.
-    bool get_is_new_target_state_set(void);
+    bool get_is_new_target_state_set() const;
 
     /// @brief Reset the flag is_new_target_state_set.
-    void reset_is_new_target_state_set(void);
+    void reset_is_new_target_state_set();
 
     /// @brief Return the timestamp at which last actual state change from closed to
     ///        open has occurred.
-    std::chrono::time_point<std::chrono::steady_clock> get_last_actual_state_open_ts(void);
+    std::chrono::time_point<std::chrono::steady_clock> get_last_actual_state_open_ts() const;
 
     /// @brief Determine if switching on is allowed or not to prevent relay wear.
     /// @Return `true` if switch on allowed, `false` otherwise.
-    bool is_switch_on_allowed(void);
+    bool is_switch_on_allowed();
 
     /// @brief Return the value of the flag delay_contactor_close.
-    bool get_delay_contactor_close(void);
+    bool get_delay_contactor_close() const;
 
     /// @brief Reset the flag delay_contactor_close.
-    void reset_delay_contactor_close(void);
+    void reset_delay_contactor_close();
 
     /// @brief Determine if there exists contactor(s) error (0 or 1).
-    bool is_error_state(void);
+    bool is_error_state() const;
 
     /// @brief Wait for new events (GPIO interrupts) occurring on the relays feedback.
     /// @param duration The maximum duration to wait for events to occur.
@@ -136,7 +136,7 @@ public:
 
     /// @brief Wait for new events (GPIO interrupts) occurring on the relays feedback.
     /// @return '0' it is a contactor opened event, '1' if it is a contactor closed event.
-    bool read_events(void);
+    bool read_events();
 
 private:
     /// @brief Object representing the first relay on the Tarragon board.
@@ -181,3 +181,8 @@ private:
     /// @brief Return current state based on evaluation of current GPIOs.
     ContactorState get_current_state();
 };
+
+/// @brief Feeds a string representation of the given CbTarragonContactorControl
+///        instance into an output stream.
+/// @return A reference to the output stream operated on.
+std::ostream& operator<<(std::ostream& os, const CbTarragonContactorControl& cc);

--- a/modules/CbTarragonDriver/tarragon/CbTarragonContactorControl.hpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonContactorControl.hpp
@@ -33,11 +33,11 @@ enum class StateType {
 /// For phase-count switching setups, only the so called 'serial' wiring setup is supported.
 /// This means, that the primary contactor (controlled via relay 1) either switches all 3 phases or
 /// at least the first one, and the secondary contactor switches phase 2 and 3. But the important aspect
-/// here is that the secondary contactor is first switch on, and switched off last, while the primary
-/// contactor is switch on last, and switched off first. The sequence is required to present a consistent
-/// "theses phase are available" view to the car - in other words, the phases do not arrive with a
+/// here is that the secondary contactor is first switched on, and switched off last, while the primary
+/// contactor is switched on last, and switched off first. The sequence is required to present a consistent
+/// "these phases are available" view to the car - in other words, the phases do not arrive with a
 /// time lag at the car.
-/// Note on the implementation: in case phase-count switching is not enabled, we interally handle this
+/// Note on the implementation: in case phase-count switching is not enabled, we internally handle this
 /// as single phase mode (because in this case, the real-world number of phases does not matter).
 ///
 class CbTarragonContactorControl {

--- a/modules/CbTarragonDriver/tarragon/CbTarragonContactorControl.hpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonContactorControl.hpp
@@ -42,19 +42,25 @@ public:
     /// @param relay_1_actuator_gpio_line_name The name of the GPIO line which switches the first relay on/off.
     /// @param relay_1_feedback_gpio_line_name The name of the GPIO line to which the feedback/sense signal of relay 1
     /// is connected to.
+    /// @param relay_1_feedback_gpio_deboucne_us The debounce period which should be configured on the GPIO line in
+    /// microseconds. Pass zero to skip the configuration of any debounce period.
     /// @param contactor_1_feedback_type Defines the logic behind the feedback (no = normally open, nc = normally close,
     /// none = no feedback).
     /// @param relay_2_name The name of the second relay and its feedback as labeled on hardware.
     /// @param relay_2_actuator_gpio_line_name The name of the GPIO line which switches the second relay on/off.
     /// @param relay_2_feedback_gpio_line_name The name of the GPIO line to which the feedback/sense signal of relay 2
     /// is connected to.
+    /// @param relay_2_feedback_gpio_deboucne_us The debounce period which should be configured on the GPIO line in
+    /// microseconds. Pass zero to skip the configuration of any debounce period.
     /// @param contactor_2_feedback_type Defines the logic behind the feedback (no = normally open, nc = normally close,
     /// none = no feedback).
     CbTarragonContactorControl(const std::string& relay_1_name, const std::string& relay_1_actuator_gpio_line_name,
                                const std::string& relay_1_feedback_gpio_line_name,
+                               const unsigned int relay_1_gpio_debounce_us,
                                const std::string& contactor_1_feedback_type, const std::string& relay_2_name,
                                const std::string& relay_2_actuator_gpio_line_name,
                                const std::string& relay_2_feedback_gpio_line_name,
+                               const unsigned int relay_2_gpio_debounce_us,
                                const std::string& contactor_2_feedback_type);
 
     /// @brief Get the state of one or both contactors (OPEN or CLOSED).

--- a/modules/CbTarragonDriver/tarragon/CbTarragonRelay.hpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonRelay.hpp
@@ -26,8 +26,11 @@ public:
     /// feedback).
     /// @param feedback_gpio_line_name The name of the GPIO line to which the feedback/sense signal of relay 1 is
     /// connected to.
+    /// @param feedback_gpio_debounce_us The debounce period which should be configured for the feedback GPIO (in [us]).
+    /// Pass a value of zero to skip any configuration.
     CbTarragonRelay(const std::string& relay_name, const std::string& actuator_gpio_line_name,
-                    const std::string& feedback_type, const std::string& feedback_gpio_line_name);
+                    const std::string& feedback_type, const std::string& feedback_gpio_line_name,
+                    const unsigned int feedback_gpio_debounce_us);
 
     /// @brief Set the timestamp of the last contactor state change from closed to open
     void set_last_contactor_open_ts(std::chrono::time_point<std::chrono::steady_clock> timestamp);


### PR DESCRIPTION
This PR adds support for phase-count switching with a 'serial' setup, i.e. when the secondary contactor is wired in series to the primary contactor.
