### PR TITLE
CbSystem: set system time via SDBus instead of command line utility

### DIFF
--- a/modules/CbSystem/CMakeLists.txt
+++ b/modules/CbSystem/CMakeLists.txt
@@ -9,6 +9,9 @@ ev_setup_cpp_module()
 
 # ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
 # insert your custom targets and additional config variables here
+pkg_search_module(LIBSYSTEMD REQUIRED libsystemd)
+target_link_libraries(${MODULE_NAME} PUBLIC ${LIBSYSTEMD_LIBRARIES})
+
 set (ADDITIONAL_MODULE_LIBS everest::timer)
 
 list(APPEND ADDITIONAL_MODULE_LIBS

--- a/modules/CbSystem/CbSystem.hpp
+++ b/modules/CbSystem/CbSystem.hpp
@@ -23,6 +23,7 @@ struct Conf {
     double DefaultRetries;
     double DefaultRetryInterval;
     int ResetDelay;
+    int min_time_deviation;
 };
 
 class CbSystem : public Everest::ModuleBase {

--- a/modules/CbSystem/CbSystem.hpp
+++ b/modules/CbSystem/CbSystem.hpp
@@ -20,9 +20,9 @@
 namespace module {
 
 struct Conf {
-    double DefaultRetries;
-    double DefaultRetryInterval;
-    int ResetDelay;
+    int default_retries;
+    int default_retry_interval;
+    int reset_delay;
     int min_time_deviation;
 };
 

--- a/modules/CbSystem/main/systemImpl.cpp
+++ b/modules/CbSystem/main/systemImpl.cpp
@@ -256,9 +256,9 @@ void systemImpl::standard_firmware_update(const types::system::FirmwareUpdateReq
         const std::vector<std::string> args = {constants.string(), firmware_update_request.location,
                                                firmware_file_path.string()};
         int32_t retries = 0;
-        const auto total_retries = firmware_update_request.retries.value_or(this->mod->config.DefaultRetries);
+        const auto total_retries = firmware_update_request.retries.value_or(this->mod->config.default_retries);
         const auto retry_interval =
-            firmware_update_request.retry_interval_s.value_or(this->mod->config.DefaultRetryInterval);
+            firmware_update_request.retry_interval_s.value_or(this->mod->config.default_retry_interval);
 
         auto firmware_status_enum = types::system::FirmwareUpdateStatusEnum::DownloadFailed;
         types::system::FirmwareUpdateStatus firmware_status;
@@ -423,9 +423,9 @@ void systemImpl::download_signed_firmware(const types::system::FirmwareUpdateReq
         constants.string(), firmware_update_request.location, firmware_file_path.string(),
         firmware_update_request.signature.value(), firmware_update_request.signing_certificate.value()};
     int32_t retries = 0;
-    const auto total_retries = firmware_update_request.retries.value_or(this->mod->config.DefaultRetries);
+    const auto total_retries = firmware_update_request.retries.value_or(this->mod->config.default_retries);
     const auto retry_interval =
-        firmware_update_request.retry_interval_s.value_or(this->mod->config.DefaultRetryInterval);
+        firmware_update_request.retry_interval_s.value_or(this->mod->config.default_retry_interval);
 
     auto firmware_status_enum = types::system::FirmwareUpdateStatusEnum::DownloadFailed;
     types::system::FirmwareUpdateStatus firmware_status;
@@ -670,9 +670,9 @@ systemImpl::handle_upload_logs(types::system::UploadLogsRequest& upload_logs_req
                                          diagnostics_file_path.string()};
         bool uploaded = false;
         int32_t retries = 0;
-        const auto total_retries = upload_logs_request.retries.value_or(this->mod->config.DefaultRetries);
+        const auto total_retries = upload_logs_request.retries.value_or(this->mod->config.default_retries);
         const auto retry_interval =
-            upload_logs_request.retry_interval_s.value_or(this->mod->config.DefaultRetryInterval);
+            upload_logs_request.retry_interval_s.value_or(this->mod->config.default_retry_interval);
 
         types::system::LogStatus log_status;
         while (!uploaded && retries <= total_retries && !this->interrupt_log_upload) {
@@ -733,7 +733,7 @@ void systemImpl::handle_reset(types::system::ResetType& type, bool& scheduled) {
     std::thread([this, type, scheduled] {
         EVLOG_info << "Reset request received: " << type << ", " << (scheduled ? "" : "not ") << "scheduled";
 
-        std::this_thread::sleep_for(std::chrono::seconds(this->mod->config.ResetDelay));
+        std::this_thread::sleep_for(std::chrono::seconds(this->mod->config.reset_delay));
 
         if (type == types::system::ResetType::Soft) {
             EVLOG_info << "Performing soft reset now.";

--- a/modules/CbSystem/main/systemImpl.cpp
+++ b/modules/CbSystem/main/systemImpl.cpp
@@ -200,6 +200,7 @@ void systemImpl::setSystemTime(const std::chrono::time_point<date::utc_clock>& t
 
     rv = sd_bus_default_system(&bus);
     if (rv < 0) {
+        sd_bus_close(bus);
         throw std::system_error(errno, std::generic_category(), "Could not initialize SDBus");
     }
 
@@ -209,11 +210,13 @@ void systemImpl::setSystemTime(const std::chrono::time_point<date::utc_clock>& t
     rv = sd_bus_call_method(bus, bus_timedate_destination, bus_timedate_path, bus_timedate_interface, "SetTime",
                             &sd_error, NULL, sb_bus_types, usec_utc_sys, relative, interactive);
     if (rv < 0) {
+        sd_bus_close(bus);
         throw std::system_error(errno, std::generic_category(), "Could not call SDBus method");
     }
 
     rv = sd_bus_flush(bus);
     if (rv < 0) {
+        sd_bus_close(bus);
         throw std::system_error(errno, std::generic_category(), "Could not flush SDBus");
     }
 

--- a/modules/CbSystem/main/systemImpl.cpp
+++ b/modules/CbSystem/main/systemImpl.cpp
@@ -760,7 +760,7 @@ bool systemImpl::handle_set_system_time(std::string& timestamp) {
 
     // pass time to system
     try {
-        setSystemTime(new_timepoint);
+        this->setSystemTime(new_timepoint);
     } catch (const std::system_error& e) {
         EVLOG_error << "System error setting time: [" << e.code() << "] " << e.what();
         return false;

--- a/modules/CbSystem/main/systemImpl.cpp
+++ b/modules/CbSystem/main/systemImpl.cpp
@@ -177,14 +177,14 @@ void systemImpl::check_update_marker() {
     }
 }
 
-bool systemImpl::setSystemTime(const std::chrono::time_point<date::utc_clock>& timepoint) {
+void systemImpl::setSystemTime(const std::chrono::time_point<date::utc_clock>& timepoint) {
     // we ignore:
     // - enabling or checking of NTP support
     // - checking the time difference
     // we do only:
     // - set the system time with the simplest and most straight-forward method
     //   (SDBus)
-    // - return a success indicator
+    // - throw on errors
     __attribute__((cleanup(sd_bus_error_free))) sd_bus_error sd_error = SD_BUS_ERROR_NULL;
     __attribute__((cleanup(sd_bus_unrefp))) sd_bus* bus = NULL;
     const char* bus_timedate_destination = "org.freedesktop.timedate1";
@@ -195,36 +195,30 @@ bool systemImpl::setSystemTime(const std::chrono::time_point<date::utc_clock>& t
     int rv;
 
     const auto timepoint_us = std::chrono::time_point_cast<std::chrono::microseconds>(timepoint);
-    const auto usec_utc = timepoint_us.time_since_epoch(); // FIXME .count()
+    const auto usec_utc = timepoint_us.time_since_epoch();
 
     rv = sd_bus_default_system(&bus);
     if (rv < 0) {
-        // FIXME: throw std::strerror(errno) instead of bool return
-        return false;
+        throw std::system_error(errno, std::generic_category(), "Could not initialize SDBus");
     }
 
     rv = sd_bus_call_method(bus, bus_timedate_destination, bus_timedate_path, bus_timedate_interface, "SetTime",
                             &sd_error, NULL, "xbb", usec_utc, relative, interactive);
     if (rv < 0) {
-        // FIXME: throw std::strerror(errno) instead of bool return
-        return false;
+        throw std::system_error(errno, std::generic_category(), "Could not call SDBus method");
     }
 
     rv = sd_bus_flush(bus);
     if (rv < 0) {
-        // FIXME: throw std::strerror(errno) instead of bool return
-        return false;
+        throw std::system_error(errno, std::generic_category(), "Could not flush SDBus");
     }
 
     sd_bus_close(bus);
 
     if (sd_bus_error_is_set(&sd_error)) {
         /* TODO we might return/show the error string here from the error object */
-        // FIXME: throw std::strerror(errno) instead of bool return
-        return false;
+        throw std::system_error(errno, std::generic_category(), "SDBus operation returned an error");
     }
-
-    return true;
 }
 
 void systemImpl::standard_firmware_update(const types::system::FirmwareUpdateRequest& firmware_update_request) {
@@ -741,8 +735,6 @@ void systemImpl::handle_reset(types::system::ResetType& type, bool& scheduled) {
 }
 
 bool systemImpl::handle_set_system_time(std::string& timestamp) {
-    int rv = 1;
-
     // FIXME: Time is set on every Heartbeat due to milliseconds differences. This needs a proper fix
     static bool time_is_set = false;
 
@@ -751,11 +743,17 @@ bool systemImpl::handle_set_system_time(std::string& timestamp) {
         // convert RFC3339 time to std::chrono::time_point
         const auto timepoint = Everest::Date::from_rfc3339(timestamp);
         // pass time to system
-        rv = setSystemTime(timepoint);
-        time_is_set = true;
+        try {
+            setSystemTime(timepoint);
+            time_is_set = true;
+        }
+        catch (const std::system_error& e) {
+            EVLOG_error << "System error setting time: [" << e.code() << "] " << e.what();
+            return false;
+        }
     }
 
-    return (rv == 0);
+    return true;
 };
 
 types::system::BootReason systemImpl::handle_get_boot_reason() {

--- a/modules/CbSystem/main/systemImpl.cpp
+++ b/modules/CbSystem/main/systemImpl.cpp
@@ -216,8 +216,11 @@ void systemImpl::setSystemTime(const std::chrono::time_point<date::utc_clock>& t
     sd_bus_close(bus);
 
     if (sd_bus_error_is_set(&sd_error)) {
-        /* TODO we might return/show the error string here from the error object */
-        throw std::system_error(errno, std::generic_category(), "SDBus operation returned an error");
+        std::stringstream ss;
+        ss << "SDBus operation returned an error named '" << sd_error.name << "', message: '" << sd_error.message
+           << "'";
+        // EIO is a random choice
+        throw std::system_error(EIO, std::generic_category(), ss.str());
     }
 }
 

--- a/modules/CbSystem/main/systemImpl.cpp
+++ b/modules/CbSystem/main/systemImpl.cpp
@@ -23,7 +23,7 @@ namespace main {
 namespace fs = std::filesystem;
 using namespace std::literals::chrono_literals;
 
-const std::chrono::milliseconds min_clock_deviation = 2s;
+const std::chrono::milliseconds min_clock_deviation = 500ms;
 
 const std::string CONSTANTS = "constants.env";
 const std::string DIAGNOSTICS_UPLOADER = "diagnostics_uploader.sh";

--- a/modules/CbSystem/main/systemImpl.cpp
+++ b/modules/CbSystem/main/systemImpl.cpp
@@ -23,8 +23,6 @@ namespace main {
 namespace fs = std::filesystem;
 using namespace std::literals::chrono_literals;
 
-const std::chrono::milliseconds min_clock_deviation = 500ms;
-
 const std::string CONSTANTS = "constants.env";
 const std::string DIAGNOSTICS_UPLOADER = "diagnostics_uploader.sh";
 const std::string FIRMWARE_UPDATER = "firmware_updater.sh";
@@ -752,6 +750,10 @@ bool systemImpl::handle_set_system_time(std::string& timestamp) {
     // do not adjust small differences
     const std::chrono::milliseconds sys_clock_diff =
         std::chrono::duration_cast<std::chrono::milliseconds>(timepoint - date::utc_clock::now());
+
+    const std::chrono::milliseconds min_clock_deviation =
+        std::chrono::milliseconds(this->mod->config.min_time_deviation);
+
     if (std::chrono::abs(sys_clock_diff) < min_clock_deviation) {
         EVLOG_debug << "Skipped setting system time to: " << timestamp
                     << ", difference is: " << std::to_string(sys_clock_diff.count()) << " ms";

--- a/modules/CbSystem/main/systemImpl.cpp
+++ b/modules/CbSystem/main/systemImpl.cpp
@@ -190,23 +190,24 @@ void systemImpl::setSystemTime(const std::chrono::time_point<date::utc_clock>& t
     const char* bus_timedate_destination = "org.freedesktop.timedate1";
     const char* bus_timedate_path = "/org/freedesktop/timedate1";
     const char* bus_timedate_interface = "org.freedesktop.timedate1";
-    constexpr bool relative = false;
-    constexpr bool interactive = false;
     int rv;
 
     // date::utc_clock takes leap seconds into consideration, the SDBus system clock does not
     // so convert to eliminate to 28 seconds difference
     const auto timepoint_sys_clock = date::clock_cast<std::chrono::system_clock>(timepoint);
     const auto timepoint_sys_clock_us = std::chrono::time_point_cast<std::chrono::microseconds>(timepoint_sys_clock);
-    const auto usec_utc_sys = timepoint_sys_clock_us.time_since_epoch().count();
+    const int64_t usec_utc_sys = timepoint_sys_clock_us.time_since_epoch().count();
 
     rv = sd_bus_default_system(&bus);
     if (rv < 0) {
         throw std::system_error(errno, std::generic_category(), "Could not initialize SDBus");
     }
 
+    const char* sb_bus_types = "xbb"; // int64_t, boolean, boolean
+    constexpr bool relative = false;
+    constexpr bool interactive = false;
     rv = sd_bus_call_method(bus, bus_timedate_destination, bus_timedate_path, bus_timedate_interface, "SetTime",
-                            &sd_error, NULL, "xbb", usec_utc_sys, relative, interactive);
+                            &sd_error, NULL, sb_bus_types, usec_utc_sys, relative, interactive);
     if (rv < 0) {
         throw std::system_error(errno, std::generic_category(), "Could not call SDBus method");
     }

--- a/modules/CbSystem/main/systemImpl.hpp
+++ b/modules/CbSystem/main/systemImpl.hpp
@@ -148,10 +148,9 @@ private:
     /**
      * @brief Sets the system time to the given \p timepoint .
      *
-     * @param timepoint
-     * @return bool
+     * @param timepoint a std::chrono::time_point
      */
-    bool setSystemTime(const std::chrono::time_point<date::utc_clock>& timepoint);
+    void setSystemTime(const std::chrono::time_point<date::utc_clock>& timepoint);
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
 };
 

--- a/modules/CbSystem/main/systemImpl.hpp
+++ b/modules/CbSystem/main/systemImpl.hpp
@@ -84,7 +84,7 @@ private:
     Everest::SteadyTimer signed_firmware_update_download_timer;
     Everest::SteadyTimer signed_firmware_update_install_timer;
 
-    const int MIN_TIMESTAMP_DEVIATION {500};
+    const int MIN_TIMESTAMP_DEVIATION {2000};
 
     /**
      * @brief Executes a standard firmware update using the given \p firmware_update_request

--- a/modules/CbSystem/main/systemImpl.hpp
+++ b/modules/CbSystem/main/systemImpl.hpp
@@ -144,6 +144,14 @@ private:
      *  notifies the upper layer that the firmware update was successfully installed.
      */
     void check_update_marker();
+
+    /**
+     * @brief Sets the system time to the given \p timepoint .
+     *
+     * @param timepoint
+     * @return bool
+     */
+    bool setSystemTime(const std::chrono::time_point<date::utc_clock>& timepoint);
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
 };
 

--- a/modules/CbSystem/main/systemImpl.hpp
+++ b/modules/CbSystem/main/systemImpl.hpp
@@ -84,6 +84,8 @@ private:
     Everest::SteadyTimer signed_firmware_update_download_timer;
     Everest::SteadyTimer signed_firmware_update_install_timer;
 
+    const int MIN_TIMESTAMP_DEVIATION {500};
+
     /**
      * @brief Executes a standard firmware update using the given \p firmware_update_request
      *

--- a/modules/CbSystem/main/systemImpl.hpp
+++ b/modules/CbSystem/main/systemImpl.hpp
@@ -14,6 +14,7 @@
 
 // ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
 // insert your custom include headers here
+#include <chrono>
 #include <filesystem>
 
 #include <everest/timer.hpp>
@@ -83,8 +84,6 @@ private:
     Everest::SteadyTimer standard_update_firmware_timer;
     Everest::SteadyTimer signed_firmware_update_download_timer;
     Everest::SteadyTimer signed_firmware_update_install_timer;
-
-    const int MIN_TIMESTAMP_DEVIATION {2000};
 
     /**
      * @brief Executes a standard firmware update using the given \p firmware_update_request

--- a/modules/CbSystem/manifest.yaml
+++ b/modules/CbSystem/manifest.yaml
@@ -1,15 +1,15 @@
 description: This module implements system wide operations for chargebyte's hardware products
 config:
-  DefaultRetries:
+  default_retries:
     description: Specifies how many times Charge Point tries to upload or download files on previous failure.
-    type: number
+    type: integer
     default: 1
-  DefaultRetryInterval:
+  default_retry_interval:
     description: >-
       Specifies in seconds after which time a retry of an upload or download on previous failure may be attempted.
-    type: number
+    type: integer
     default: 1
-  ResetDelay:
+  reset_delay:
     description: >-
       When receiving a reset request, then the actual execution can be delayed by this amount of time (given in seconds).
       This might be necessary, for example, when the reset request arrives via the network and the call acknowledgement

--- a/modules/CbSystem/manifest.yaml
+++ b/modules/CbSystem/manifest.yaml
@@ -18,6 +18,13 @@ config:
     type: integer
     minimum: 0
     default: 3
+  min_time_deviation:
+    description: >-
+      Specifies in milliseconds the minimum clock deviation for applying a new system time. This is to avoid frequent
+      small jumps of system time.
+    type: integer
+    minimum: 0
+    default: 1000
 provides:
   main:
     description: Implements the system interface


### PR DESCRIPTION
CbSystem was using the /bin/date command line tool to set the system time. Yet this tool does not understand RFC3339 time stamps, if it is provided by busybox.

This converts CbSystem to use the SDBus `SetTime` function via libsystemd.

Furtherfore, a check is made for the potential time difference, to not constantly set the system time due to minor variations. The threshold is currently set to 2000 ms, as setting the time sometimes leaves such an offset, for yet unknown reasons.

As with the command line utility before, no check is made for whether NTP is active and in sync - the time is just simply set.