### PR TITLE
Refactor contactor support and complete 3ph1ph switching feature with support for 'mutual' wiring

### DIFF
--- a/modules/CbTarragonDriver/CbTarragonDriver.cpp
+++ b/modules/CbTarragonDriver/CbTarragonDriver.cpp
@@ -4,6 +4,10 @@
 #include <memory>
 #include <utility>
 #include "CbTarragonDriver.hpp"
+#include <CbTarragonContactorControl.hpp>
+#include <CbTarragonContactorControlSimple.hpp>
+#include <CbTarragonContactorControlSerial.hpp>
+#include <CbTarragonContactorControlMutual.hpp>
 #include "configuration.h"
 
 namespace module {
@@ -11,6 +15,7 @@ namespace module {
 void CbTarragonDriver::init() {
     EVLOG_info << MODULE_DESCRIPTION << " (version: " << MODULE_VERSION << ")";
 
+    // create relay instances
     this->relays[this->config.relay_1_name] = std::make_unique<CbTarragonRelay>(
         this->config.relay_1_name, this->config.relay_1_actuator_gpio_line_name,
         this->config.relay_1_feedback_gpio_line_name, this->config.relay_1_feedback_gpio_debounce_us);
@@ -18,6 +23,33 @@ void CbTarragonDriver::init() {
     this->relays[this->config.relay_2_name] = std::make_unique<CbTarragonRelay>(
         this->config.relay_2_name, this->config.relay_2_actuator_gpio_line_name,
         this->config.relay_2_feedback_gpio_line_name, this->config.relay_2_feedback_gpio_debounce_us);
+
+    // contactor instance based on configuration
+    if (this->config.switch_3ph1ph_wiring == "none") {
+        // per definition we use the relay 1 as primary/only relay
+        auto nh_relay = this->relays.extract(this->config.relay_1_name);
+
+        this->contactor_controller = std::make_unique<CbTarragonContactorControlSimple>(
+            std::move(nh_relay.mapped()), this->config.contactor_1_feedback_type);
+
+    } else if (this->config.switch_3ph1ph_wiring == "serial") {
+        // per definition we use the relay 1 as primary relay (all phases)
+        // and relay 2 as secondary relay (phases 2 and 3)
+        auto nh_primary = this->relays.extract(this->config.relay_1_name);
+        auto nh_secondary = this->relays.extract(this->config.relay_2_name);
+
+        this->contactor_controller = std::make_unique<CbTarragonContactorControlSerial>(
+            std::move(nh_primary.mapped()), this->config.contactor_1_feedback_type,
+            std::move(nh_secondary.mapped()), this->config.contactor_2_feedback_type);
+    } else if (this->config.switch_3ph1ph_wiring == "mutual") {
+        // per definition we use the relay 1 as primary relay (3ph) and relay 2 as secondary relay (1ph)
+        auto nh_3ph = this->relays.extract(this->config.relay_1_name);
+        auto nh_1ph = this->relays.extract(this->config.relay_2_name);
+
+        this->contactor_controller = std::make_unique<CbTarragonContactorControlMutual>(
+            std::move(nh_3ph.mapped()), this->config.contactor_1_feedback_type, std::move(nh_1ph.mapped()),
+            this->config.contactor_2_feedback_type);
+    }
 
     invoke_init(*p_evse_board_support);
     invoke_init(*p_ac_rcd);

--- a/modules/CbTarragonDriver/CbTarragonDriver.cpp
+++ b/modules/CbTarragonDriver/CbTarragonDriver.cpp
@@ -1,15 +1,26 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Pionix GmbH and Contributors to EVerest
+#include <map>
+#include <memory>
+#include <utility>
 #include "CbTarragonDriver.hpp"
 #include "configuration.h"
 
 namespace module {
 
 void CbTarragonDriver::init() {
+    EVLOG_info << MODULE_DESCRIPTION << " (version: " << MODULE_VERSION << ")";
+
+    this->relays[this->config.relay_1_name] = std::make_unique<CbTarragonRelay>(
+        this->config.relay_1_name, this->config.relay_1_actuator_gpio_line_name,
+        this->config.relay_1_feedback_gpio_line_name, this->config.relay_1_feedback_gpio_debounce_us);
+
+    this->relays[this->config.relay_2_name] = std::make_unique<CbTarragonRelay>(
+        this->config.relay_2_name, this->config.relay_2_actuator_gpio_line_name,
+        this->config.relay_2_feedback_gpio_line_name, this->config.relay_2_feedback_gpio_debounce_us);
+
     invoke_init(*p_evse_board_support);
     invoke_init(*p_ac_rcd);
-
-    EVLOG_info << MODULE_DESCRIPTION << " (version: " << MODULE_VERSION << ")";
 }
 
 void CbTarragonDriver::ready() {

--- a/modules/CbTarragonDriver/CbTarragonDriver.hpp
+++ b/modules/CbTarragonDriver/CbTarragonDriver.hpp
@@ -16,6 +16,10 @@
 
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 // insert your custom include headers here
+#include <map>
+#include <memory>
+#include <string>
+#include "CbTarragonRelay.hpp"
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 
 namespace module {
@@ -67,6 +71,9 @@ public:
 
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
     // insert your public definitions here
+
+    /// @brief Map with platform relays
+    std::map<std::string, std::unique_ptr<CbTarragonRelay>> relays;
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
 
 protected:

--- a/modules/CbTarragonDriver/CbTarragonDriver.hpp
+++ b/modules/CbTarragonDriver/CbTarragonDriver.hpp
@@ -19,7 +19,8 @@
 #include <map>
 #include <memory>
 #include <string>
-#include "CbTarragonRelay.hpp"
+#include <CbTarragonRelay.hpp>
+#include <CbTarragonContactorControl.hpp>
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 
 namespace module {
@@ -74,6 +75,10 @@ public:
 
     /// @brief Map with platform relays
     std::map<std::string, std::unique_ptr<CbTarragonRelay>> relays;
+
+    /// @brief Relay and contactor control
+    std::unique_ptr<CbTarragonContactorControl> contactor_controller;
+
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
 
 protected:

--- a/modules/CbTarragonDriver/CbTarragonDriver.hpp
+++ b/modules/CbTarragonDriver/CbTarragonDriver.hpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <CbTarragonRelay.hpp>
 #include <CbTarragonContactorControl.hpp>
+#include <CbTarragonRCM.hpp>
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 
 namespace module {
@@ -78,6 +79,9 @@ public:
 
     /// @brief Relay and contactor control
     std::unique_ptr<CbTarragonContactorControl> contactor_controller;
+
+    /// @brief Member variable for holding RCM controller instance
+    CbTarragonRCM rcm_controller;
 
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1
 

--- a/modules/CbTarragonDriver/ac_rcd/ac_rcdImpl.cpp
+++ b/modules/CbTarragonDriver/ac_rcd/ac_rcdImpl.cpp
@@ -54,19 +54,23 @@ void ac_rcdImpl::rcm_observation_worker(void) {
 
         if (this->mod->rcm_controller.is_rcm_tripped() && !this->rcm_tripped) {
             // signal emergency state to evse_board_support interface for open the contactor immediately
-            module::evse_board_support::evse_board_supportImpl::set_emergency_state(true);
+            this->mod->rcm_controller.on_change(true);
+
+            EVLOG_debug << "RCM tripped";
             this->rcm_tripped = true;
+
             Everest::error::Error error_object = this->error_factory->create_error(
                 "ac_rcd/MREC2GroundFailure", "", "RCM failure detected", Everest::error::Severity::High);
             this->raise_error(error_object);
-            EVLOG_info << "RCM tripped";
         }
 
         if (!this->mod->rcm_controller.is_rcm_tripped() && this->rcm_tripped) {
+            EVLOG_debug << "RCM not tripped";
             this->rcm_tripped = false;
-            EVLOG_info << "RCM not tripped";
+
             // signal released emergency state to evse_board_support interface
-            module::evse_board_support::evse_board_supportImpl::set_emergency_state(false);
+            this->mod->rcm_controller.on_change(false);
+
             this->clear_error("ac_rcd/MREC2GroundFailure");
         }
     }

--- a/modules/CbTarragonDriver/ac_rcd/ac_rcdImpl.cpp
+++ b/modules/CbTarragonDriver/ac_rcd/ac_rcdImpl.cpp
@@ -15,7 +15,7 @@ void ac_rcdImpl::init() {
         EVLOG_info << "RCM GPIO: " << this->mod->config.rcm_fault_gpio_line_name;
         EVLOG_info << "RCM GPIO polarity: " << (this->mod->config.rcm_fault_active_low ? "active_low" : "active_high");
 
-        this->rcm_controller =
+        this->mod->rcm_controller =
             CbTarragonRCM(this->mod->config.rcm_fault_gpio_line_name, this->mod->config.rcm_fault_active_low);
     }
 }
@@ -50,9 +50,9 @@ void ac_rcdImpl::rcm_observation_worker(void) {
     std::this_thread::sleep_for(1s);
 
     while (!this->termination_requested) {
-        this->rcm_controller.wait_for_rcm_event(1s);
+        this->mod->rcm_controller.wait_for_rcm_event(1s);
 
-        if (this->rcm_controller.is_rcm_tripped() && !this->rcm_tripped) {
+        if (this->mod->rcm_controller.is_rcm_tripped() && !this->rcm_tripped) {
             // signal emergency state to evse_board_support interface for open the contactor immediately
             module::evse_board_support::evse_board_supportImpl::set_emergency_state(true);
             this->rcm_tripped = true;
@@ -62,7 +62,7 @@ void ac_rcdImpl::rcm_observation_worker(void) {
             EVLOG_info << "RCM tripped";
         }
 
-        if (!this->rcm_controller.is_rcm_tripped() && this->rcm_tripped) {
+        if (!this->mod->rcm_controller.is_rcm_tripped() && this->rcm_tripped) {
             this->rcm_tripped = false;
             EVLOG_info << "RCM not tripped";
             // signal released emergency state to evse_board_support interface

--- a/modules/CbTarragonDriver/ac_rcd/ac_rcdImpl.hpp
+++ b/modules/CbTarragonDriver/ac_rcd/ac_rcdImpl.hpp
@@ -14,7 +14,6 @@
 
 // ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
 #include <atomic>
-#include <CbTarragonRCM.hpp>
 #include <thread>
 // ev@75ac1216-19eb-4182-a85c-820f1fc2c091:v1
 
@@ -57,9 +56,6 @@ private:
 
     /// @brief RCM Observation thread handle
     std::thread rcm_observation_thread;
-
-    /// @brief Member variable for holding RCM controller instance
-    CbTarragonRCM rcm_controller;
 
     /// @brief Indicator whether RCM is still tripped
     std::atomic_bool rcm_tripped {false};

--- a/modules/CbTarragonDriver/evse_board_support/evse_board_supportImpl.cpp
+++ b/modules/CbTarragonDriver/evse_board_support/evse_board_supportImpl.cpp
@@ -1,10 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright Pionix GmbH and Contributors to EVerest
 
+#include <chrono>
 #include <iomanip>
+#include <map>
 #include <sstream>
 #include <string>
 #include <generated/types/cb_board_support.hpp>
+#include <CbTarragonContactorControl.hpp>
+#include <CbTarragonContactorControlSimple.hpp>
+#include <CbTarragonContactorControlSerial.hpp>
+#include <CbTarragonContactorControlMutual.hpp>
 
 #include "evse_board_supportImpl.hpp"
 
@@ -82,26 +88,96 @@ void evse_board_supportImpl::init() {
     this->pp_controller = CbTarragonPP(this->mod->config.pp_adc_device, this->mod->config.pp_adc_channel);
 
     // Relay and contactor handling
-    this->contactor_controller = CbTarragonContactorControl(
-        this->mod->config.relay_1_name, this->mod->config.relay_1_actuator_gpio_line_name,
-        this->mod->config.relay_1_feedback_gpio_line_name, this->mod->config.relay_1_feedback_gpio_debounce_us,
-        this->mod->config.contactor_1_feedback_type, this->mod->config.relay_2_name,
-        this->mod->config.relay_2_actuator_gpio_line_name, this->mod->config.relay_2_feedback_gpio_line_name,
-        this->mod->config.relay_2_feedback_gpio_debounce_us, this->mod->config.contactor_2_feedback_type,
-        support_3ph1ph);
+    if (this->mod->config.switch_3ph1ph_wiring == "none") {
+        // per definition we use the relay 1 as primary/only relay
+        auto nh_relay = this->mod->relays.extract(this->mod->config.relay_1_name);
 
-    // set the contactor handling related flags and timeout
-    this->contactor_feedback_timeout = 200ms;
-    this->allow_power_on = false;
-    this->last_allow_power_on = false;
+        this->contactor_controller = std::make_unique<CbTarragonContactorControlSimple>(
+            std::move(nh_relay.mapped()), this->mod->config.contactor_1_feedback_type);
 
-    // start contactor handling thread
-    this->contactor_handling_thread = std::thread(&evse_board_supportImpl::contactor_handling_worker, this);
+    } else if (this->mod->config.switch_3ph1ph_wiring == "serial") {
+        // per definition we use the relay 1 as primary relay (all phases)
+        // and relay 2 as secondary relay (phases 2 and 3)
+        auto nh_primary = this->mod->relays.extract(this->mod->config.relay_1_name);
+        auto nh_secondary = this->mod->relays.extract(this->mod->config.relay_2_name);
+
+        this->contactor_controller = std::make_unique<CbTarragonContactorControlSerial>(
+            std::move(nh_primary.mapped()), this->mod->config.contactor_1_feedback_type,
+            std::move(nh_secondary.mapped()), this->mod->config.contactor_2_feedback_type);
+    } else if (this->mod->config.switch_3ph1ph_wiring == "mutual") {
+        // per definition we use the relay 1 as primary relay (3ph) and relay 2 as secondary relay (1ph)
+        auto nh_3ph = this->mod->relays.extract(this->mod->config.relay_1_name);
+        auto nh_1ph = this->mod->relays.extract(this->mod->config.relay_2_name);
+
+        this->contactor_controller = std::make_unique<CbTarragonContactorControlMutual>(
+            std::move(nh_3ph.mapped()), this->mod->config.contactor_1_feedback_type, std::move(nh_1ph.mapped()),
+            this->mod->config.contactor_2_feedback_type);
+    }
+    this->contactor_controller->on_error.connect(
+        [&](const std::string& source, bool desired_state, types::cb_board_support::ContactorState actual_state) {
+            // An error occurred while switching - i.e. feedback does not match our expected new state.
+            // This fault is critical as it might be a sign of a hardware issue, therefore
+            // the fault will not be cleared to prevent further damage.
+            std::ostringstream errmsg;
+            errmsg << "Failed to " << (desired_state ? "CLOSE" : "OPEN") << " the " << source << ", it is still "
+                   << actual_state;
+
+            // raise a contactor fault if it was not done before
+            if (!this->contactor_fault_reported.exchange(true)) {
+                EVLOG_error << errmsg.str() << ", raising MREC17EVSEContactorFault.";
+
+                Everest::error::Error error_object = this->error_factory->create_error(
+                    "evse_board_support/MREC17EVSEContactorFault", "", errmsg.str(), Everest::error::Severity::High);
+                this->raise_error(error_object);
+            } else {
+                EVLOG_error << errmsg.str();
+            }
+        });
+    this->contactor_controller->on_unexpected_change.connect(
+        [&](const std::string& source, types::cb_board_support::ContactorState seen_state) {
+            // A spurious change on the feedback line should not happen and is unexpected.
+            // This fault is critical as it might be a sign of a hardware issue, therefore
+            // the fault will not be cleared to prevent further damage.
+            std::ostringstream errmsg;
+            errmsg << "Spurious state '" << seen_state << "' on feedback signal of '" << source << "' detected";
+
+            // raise a contactor fault if it was not done before
+            if (!this->contactor_fault_reported.exchange(true)) {
+                EVLOG_error << errmsg.str() << ", raising MREC17EVSEContactorFault.";
+
+                Everest::error::Error error_object = this->error_factory->create_error(
+                    "evse_board_support/MREC17EVSEContactorFault", "", errmsg.str(), Everest::error::Severity::High);
+                this->raise_error(error_object);
+            } else {
+                EVLOG_error << errmsg.str();
+            }
+        });
 }
 
 void evse_board_supportImpl::ready() {
+    std::ostringstream errmsg;
+
     // The BSP must publish this variable at least once during start up.
     this->publish_capabilities(this->hw_capabilities);
+
+    // let's pre-init the error message: the `is_inconsistent_state` method appends to the stream
+    // in case of error, otherwise the stream is left untouched
+    errmsg << "Initial contactor feedback check failed for ";
+
+    // let's check the current contactor state and raise a contactor fault in case there is anything unexpected
+    if (this->contactor_controller->is_inconsistent_state(errmsg)) {
+        // raise a contactor fault if it was not done before
+        if (!this->contactor_fault_reported.exchange(true)) {
+            EVLOG_error << errmsg.str()
+                        << ", raising MREC17EVSEContactorFault. Please double-check your configuration.";
+
+            Everest::error::Error error_object = this->error_factory->create_error(
+                "evse_board_support/MREC17EVSEContactorFault", "", errmsg.str(), Everest::error::Severity::High);
+            this->raise_error(error_object);
+        } else {
+            EVLOG_error << errmsg.str() << ". Please double-check your configuration.";
+        }
+    }
 }
 
 void evse_board_supportImpl::set_emergency_state(bool is_emergency) {
@@ -134,13 +210,6 @@ evse_board_supportImpl::~evse_board_supportImpl() {
     // if thread exists and is active wait until it is terminated
     if (this->pp_observation_thread.joinable())
         this->pp_observation_thread.join();
-
-    // set the contactor to a safe state
-    this->contactor_controller.set_target_state(ContactorState::CONTACTOR_OPEN);
-
-    // If thread is active wait until it is terminated
-    if (this->contactor_handling_thread.joinable())
-        this->contactor_handling_thread.join();
 }
 
 void evse_board_supportImpl::handle_enable(bool& value) {
@@ -195,25 +264,62 @@ void evse_board_supportImpl::handle_pwm_F() {
 }
 
 void evse_board_supportImpl::handle_allow_power_on(types::evse_board_support::PowerOnOff& value) {
+    // this method is called very often, even the contactor state is already matching the desired one
+    // so let's use a little helper to control the log noise a little bit
+    bool log_as_info = value.allow_power_on != this->contactor_controller->get_state();
 
     if (value.allow_power_on && this->cp_current_state == types::cb_board_support::CPState::PilotFault) {
-        EVLOG_warning << "Power on rejected due to detected pilot fault.";
+        EVLOG_warning << "Power on rejected due to detected pilot fault";
         return;
     }
 
-    if (evse_board_supportImpl::is_emergency) {
-        EVLOG_warning << "Power on rejected due to detected emergency state.";
+    if (value.allow_power_on && evse_board_supportImpl::is_emergency) {
+        EVLOG_warning << "Power on rejected due to detected emergency state";
         return;
     }
 
-    this->allow_power_on = value.allow_power_on;
+    if (value.allow_power_on && this->contactor_fault_reported) {
+        EVLOG_warning << "Power on rejected due to contactor fault present";
+        return;
+    }
+
+    if (log_as_info)
+        EVLOG_info << "handle_allow_power_on: request to " << (value.allow_power_on ? "CLOSE" : "OPEN")
+                   << " the contactor";
+    else
+        EVLOG_debug << "handle_allow_power_on: request to " << (value.allow_power_on ? "CLOSE" : "OPEN")
+                    << " the contactor";
+
+    if (value.allow_power_on) {
+        auto delay = this->contactor_controller->get_closing_delay_left();
+        if (delay > 0ms) {
+            std::chrono::duration<double> seconds = std::chrono::duration_cast<std::chrono::duration<double>>(delay);
+
+            EVLOG_warning << "Contactor close throttling in effect: closing will be delayed by " << std::fixed
+                          << std::setprecision(1) << seconds.count() << "s";
+        }
+    }
+    if (this->contactor_controller->switch_state(value.allow_power_on)) {
+        if (log_as_info)
+            EVLOG_info << "Current state: " << *this->contactor_controller;
+        else
+            EVLOG_debug << "Current state: " << *this->contactor_controller;
+
+        // publish PowerOn or PowerOff event
+        types::board_support_common::Event tmp_event = value.allow_power_on
+                                                           ? types::board_support_common::Event::PowerOn
+                                                           : types::board_support_common::Event::PowerOff;
+        types::board_support_common::BspEvent tmp {tmp_event};
+        this->publish_event(tmp);
+    }
+    // Note: errors while switching the contactor are reported and handled via on_error slot
 }
 
 void evse_board_supportImpl::handle_ac_switch_three_phases_while_charging(bool& value) {
     EVLOG_info << "handle_ac_switch_three_phases_while_charging: switching to " << (value ? "3-phase" : "1-phase")
                << " mode";
 
-    this->contactor_controller.switch_phase_count(value);
+    this->contactor_controller->switch_phase_count(value);
 }
 
 void evse_board_supportImpl::handle_evse_replug(int& value) {
@@ -451,130 +557,6 @@ void evse_board_supportImpl::cp_observation_worker(void) {
     }
 
     EVLOG_info << "Control Pilot Observation Thread terminated";
-}
-
-void evse_board_supportImpl::contactor_handling_worker(void) {
-    EVLOG_info << "Contactor Handling Thread started";
-
-    while (!this->termination_requested) {
-        ContactorState contactor_state {ContactorState::CONTACTOR_OPEN};
-
-        if (evse_board_supportImpl::is_emergency)
-            this->allow_power_on = false;
-
-        // set the new contactor target state
-        if (this->last_allow_power_on != this->allow_power_on) {
-            this->last_allow_power_on = this->allow_power_on;
-
-            EVLOG_info << (this->allow_power_on ? "Closing" : "Opening") << " contactor...";
-
-            this->contactor_controller.set_target_state(this->allow_power_on ? ContactorState::CONTACTOR_CLOSED
-                                                                             : ContactorState::CONTACTOR_OPEN);
-
-        } else if ((this->contactor_controller.get_delay_contactor_close() == false) &&
-                   (((this->mod->config.contactor_1_feedback_type == "none") &&
-                     (this->mod->config.contactor_2_feedback_type == "none")) ||
-                    ((this->mod->config.contactor_1_feedback_type == "none") &&
-                     (this->contactor_controller.get_target_phase_count() == 1)))) {
-            // if there is no new target states to set, we should monitor the contactor feedback through edge events.
-            // If no new edge events for contactor feedback are expected because the relays have no feedback
-            // connected to them, and we are not intentionally delaying switching on, we should simulate the
-            // actual state and send the corresponding events to the higher layer. Note that his should only happen if:
-            // - Either both contactors have no feedback, because if at least one of them has feedback, the waiting
-            //   mechanism for edge events should take place
-            // - OR if we are in single phase operation and the first contactor has no feedback
-
-            // in case a new target state is set, we need to update the actual state by simply setting
-            // it to be equal to the required target state
-            if (this->contactor_controller.is_error_state()) {
-                this->contactor_controller.set_actual_state(
-                    this->contactor_controller.get_state(StateType::TARGET_STATE));
-                EVLOG_info << "Contactor state: " << this->contactor_controller;
-
-                // publish PowerOn or PowerOff event
-                types::board_support_common::Event tmp_event =
-                    (this->contactor_controller.get_state(StateType::TARGET_STATE) == ContactorState::CONTACTOR_CLOSED)
-                        ? types::board_support_common::Event::PowerOn
-                        : types::board_support_common::Event::PowerOff;
-                types::board_support_common::BspEvent tmp {tmp_event};
-                this->publish_event(tmp);
-            }
-
-            // intentional sleep because no feedback monitoring is needed
-            std::this_thread::sleep_for(200ms);
-
-        } else if (this->contactor_controller.wait_for_events(20ms) == true) {
-            // otherwise wait for edge events to happen on one or both contactors
-
-            // Read if the new event is a contactor closed or opened event
-            contactor_state = this->contactor_controller.read_events() ? ContactorState::CONTACTOR_CLOSED
-                                                                       : ContactorState::CONTACTOR_OPEN;
-
-            // if it is a new event, set the actual state
-            if (contactor_state == this->contactor_controller.get_state(StateType::TARGET_STATE) &&
-                contactor_state != this->contactor_controller.get_state(StateType::ACTUAL_STATE)) {
-                // if the received state is equal to the expected state, set the actual state
-                this->contactor_controller.set_actual_state(contactor_state);
-                EVLOG_info << "Contactor state: " << this->contactor_controller;
-
-                // publish PowerOn or PowerOff event
-                types::board_support_common::Event tmp_event = (contactor_state == ContactorState::CONTACTOR_CLOSED)
-                                                                   ? types::board_support_common::Event::PowerOn
-                                                                   : types::board_support_common::Event::PowerOff;
-                types::board_support_common::BspEvent tmp {tmp_event};
-                this->publish_event(tmp);
-            }
-
-        } else {
-            // if we are actually waiting for a new state but it has not been detected yet
-            if (this->contactor_controller.is_error_state()) {
-
-                // if no contactor feedback has been detected but we are intentionally delaying switching on
-                // the contactor to prevent wearout. Contactor is only allowed to be switched on once every 10 seconds
-                if ((this->contactor_controller.is_switch_on_allowed() == true) &&
-                    (this->contactor_controller.get_delay_contactor_close() == true) &&
-                    (this->contactor_controller.get_state(StateType::TARGET_STATE) ==
-                     ContactorState::CONTACTOR_CLOSED)) {
-                    // set the target state again to switch on the contactor
-                    this->contactor_controller.set_target_state(ContactorState::CONTACTOR_CLOSED);
-
-                    this->contactor_controller.reset_delay_contactor_close();
-                }
-
-                else if ((this->contactor_controller.get_delay_contactor_close() == true) &&
-                         (((this->mod->config.contactor_1_feedback_type == "none") &&
-                           (this->mod->config.contactor_2_feedback_type == "none")) ||
-                          ((this->mod->config.contactor_1_feedback_type == "none") &&
-                           (this->contactor_controller.get_target_phase_count() == 1)))) {
-                    // intentional sleep because no feedback monitoring is needed and we know that we are waiting
-                    // for the 10 seconds timeout regarding relay wear prevention to pass
-                    std::this_thread::sleep_for(200ms);
-                }
-
-                else if ((this->contactor_controller.get_delay_contactor_close() == false) &&
-                         (this->contactor_controller.get_is_new_target_state_set() == true) &&
-                         (std::chrono::steady_clock::now() - this->contactor_controller.get_new_target_state_ts() >
-                          this->contactor_feedback_timeout)) {
-                    // if no new events for contactor feedback have been detected for 200ms after a new
-                    // target state was set
-                    EVLOG_error << "Failed to detect feedback. Contactor should be: "
-                                << this->contactor_controller.get_state(StateType::TARGET_STATE);
-
-                    // publish a 'contactor fault' event to the upper layer. This fault is critical as it might be a
-                    // sign of a hardware issue, therefore the fault will not be cleared to prevent further damage.
-                    Everest::error::Error error_object = this->error_factory->create_error(
-                        "evse_board_support/MREC17EVSEContactorFault", "", "Unexpected contactor feedback",
-                        Everest::error::Severity::High);
-                    this->raise_error(error_object);
-
-                    // reset the flag that marked the start of counting the contactor_feedback_timeout
-                    this->contactor_controller.reset_is_new_target_state_set();
-                }
-            }
-        }
-    }
-
-    EVLOG_info << "Contactor Handling Thread terminated";
 }
 
 } // namespace evse_board_support

--- a/modules/CbTarragonDriver/evse_board_support/evse_board_supportImpl.hpp
+++ b/modules/CbTarragonDriver/evse_board_support/evse_board_supportImpl.hpp
@@ -17,6 +17,9 @@
 
 #include <atomic>
 #include <chrono>
+#include <memory>
+#include <mutex>
+#include <thread>
 #include <generated/types/cb_board_support.hpp>
 #include <CbTarragonCP.hpp>
 #include <CbTarragonPWM.hpp>
@@ -94,7 +97,10 @@ private:
     CbTarragonPWM pwm_controller;
 
     /// @brief Relay and contactor control
-    CbTarragonContactorControl contactor_controller;
+    std::unique_ptr<CbTarragonContactorControl> contactor_controller;
+
+    /// @brief Flag to remember whether we already published a contactor fault.
+    std::atomic_bool contactor_fault_reported {false};
 
     /// @brief Mutex to enable/disable CP observation thread. Usually hold by the observation
     ///        worker thread but can be requested via `disable_cp_observation` method.
@@ -124,16 +130,6 @@ private:
     /// @brief PP observation thread handle
     std::thread pp_observation_thread;
 
-    /// @brief Duration to wait for contactor feedback before issuing a contactor fault.
-    ///        A value of 200ms should suffice for both contactors.
-    std::chrono::milliseconds contactor_feedback_timeout;
-
-    /// @brief Previous value of flag `allow_power_on`;
-    bool last_allow_power_on {false};
-
-    /// @brief Contactor handling thread handle
-    std::thread contactor_handling_thread;
-
     /// @brief Helper to determine the CP state based on the measured voltages
     types::cb_board_support::CPState determine_cp_state(const CPUtils::cp_state_signal_side& cp_state_positive_side,
                                                         const CPUtils::cp_state_signal_side& cp_state_negative_side,
@@ -150,15 +146,6 @@ private:
 
     /// @brief Main function of the PP observation thread
     void pp_observation_worker(void);
-
-    /// @brief Main function of the contactor handling thread. This is responsible for both setting
-    ///        the target state of the relay actuator and waiting for the contactor feedback
-    //         to be received.
-    void contactor_handling_worker(void);
-
-    /// @brief Signal from upper layers to determine if relays can be switched on
-    ///        (`true`: Switch on allowed, `false`: Switch off)
-    std::atomic_bool allow_power_on {false};
 
     /// @brief Signal from other interface to determine if an emergency state (e.g. RCD error) is present
     ///        (`true`: emergency present, `false`: emergency not present)

--- a/modules/CbTarragonDriver/evse_board_support/evse_board_supportImpl.hpp
+++ b/modules/CbTarragonDriver/evse_board_support/evse_board_supportImpl.hpp
@@ -96,9 +96,6 @@ private:
     /// @brief Control Pilot generation
     CbTarragonPWM pwm_controller;
 
-    /// @brief Relay and contactor control
-    std::unique_ptr<CbTarragonContactorControl> contactor_controller;
-
     /// @brief Flag to remember whether we already published a contactor fault.
     std::atomic_bool contactor_fault_reported {false};
 

--- a/modules/CbTarragonDriver/evse_board_support/evse_board_supportImpl.hpp
+++ b/modules/CbTarragonDriver/evse_board_support/evse_board_supportImpl.hpp
@@ -44,10 +44,6 @@ public:
     // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
     // insert your public definitions here
     ~evse_board_supportImpl();
-
-    /// @brief setter method to signal a emergency
-    /// @param is_emergency
-    static void set_emergency_state(bool is_emergency);
     // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
 
 protected:
@@ -144,9 +140,6 @@ private:
     /// @brief Main function of the PP observation thread
     void pp_observation_worker(void);
 
-    /// @brief Signal from other interface to determine if an emergency state (e.g. RCD error) is present
-    ///        (`true`: emergency present, `false`: emergency not present)
-    inline static std::atomic_bool is_emergency {false};
     // ev@3370e4dd-95f4-47a9-aaec-ea76f34a66c9:v1
 };
 

--- a/modules/CbTarragonDriver/manifest.yaml
+++ b/modules/CbTarragonDriver/manifest.yaml
@@ -179,5 +179,4 @@ provides:
 metadata:
   license: https://spdx.org/licenses/Apache-2.0.html
   authors:
-    - Fabian Hartung
-    - Mohannad Oraby
+    - chargebyte GmbH

--- a/modules/CbTarragonDriver/tarragon/CMakeLists.txt
+++ b/modules/CbTarragonDriver/tarragon/CMakeLists.txt
@@ -10,7 +10,11 @@ target_sources(tarragon
         "CbTarragonPP.cpp"
         "CbTarragonRCM.cpp"
         "CbTarragonRelay.cpp"
+        "CbTarragonContactor.cpp"
         "CbTarragonContactorControl.cpp"
+        "CbTarragonContactorControlSimple.cpp"
+        "CbTarragonContactorControlSerial.cpp"
+        "CbTarragonContactorControlMutual.cpp"
 )
 
 get_property(LINUX_HW_INCLUDE_DIR GLOBAL PROPERTY LINUX_HW_INCLUDE_DIR)

--- a/modules/CbTarragonDriver/tarragon/CbTarragonContactor.cpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonContactor.cpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright chargebyte GmbH and Contributors to EVerest
+#include <chrono>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <sigslot/signal.hpp>
+#include <generated/types/cb_board_support.hpp>
+#include "CbTarragonRelay.hpp"
+#include "CbTarragonContactor.hpp"
+
+CbTarragonContactor::CbTarragonContactor(const std::string& name, std::unique_ptr<CbTarragonRelay> relay,
+                                         const std::string& contactor_feedback_type) :
+    name(name),
+    feedback_type(types::cb_board_support::string_to_contactor_feedback_type(contactor_feedback_type)),
+    relay(std::move(relay)) {
+    // register error handler
+    this->relay->on_unexpected_change.connect([&](const std::string& relay_name, bool seen_state) {
+        types::cb_board_support::ContactorState seen_contactor_state {
+            seen_state ? types::cb_board_support::ContactorState::Closed
+                       : types::cb_board_support::ContactorState::Open};
+
+        this->on_unexpected_change(this->name + "@" + relay_name, seen_contactor_state);
+    });
+
+    // start the monitoring of the feedback contact (if desired);
+    // when the wired feedback is normally-closed type, then we see a physical HIGH on underlying
+    // GPIO when the contactor is considered open, thus we need to invert the used logic
+    this->relay->start(this->feedback_type != types::cb_board_support::ContactorFeedbackType::none,
+                       this->feedback_type == types::cb_board_support::ContactorFeedbackType::nc);
+}
+
+const std::string& CbTarragonContactor::get_name() const {
+    return this->name;
+}
+
+bool CbTarragonContactor::switch_state(bool on, bool wait_for_feedback) {
+    return this->relay->set_actuator_state(on, wait_for_feedback);
+}
+
+bool CbTarragonContactor::get_state() const {
+    return this->relay->get_actuator_state();
+}
+
+types::cb_board_support::ContactorState CbTarragonContactor::get_feedback_state() const {
+    return this->relay->get_feedback_state() ? types::cb_board_support::ContactorState::Closed
+                                             : types::cb_board_support::ContactorState::Open;
+}
+
+bool CbTarragonContactor::is_state_mismatch() const {
+    return this->relay->get_actuator_state() != this->relay->get_feedback_state();
+}
+
+void CbTarragonContactor::set_expected_feedback_change(bool on) {
+    this->relay->set_expected_feedback_change(on);
+}
+
+std::chrono::milliseconds CbTarragonContactor::get_closing_delay_left() const {
+    return this->relay->get_closing_delay_left();
+}
+
+std::ostream& operator<<(std::ostream& os, const CbTarragonContactor& c) {
+    os << c.name << "@" << *c.relay;
+    return os;
+}

--- a/modules/CbTarragonDriver/tarragon/CbTarragonContactor.hpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonContactor.hpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright chargebyte GmbH and Contributors to EVerest
 #pragma once
+#include <atomic>
 #include <chrono>
 #include <iostream>
 #include <memory>

--- a/modules/CbTarragonDriver/tarragon/CbTarragonContactor.hpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonContactor.hpp
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright chargebyte GmbH and Contributors to EVerest
+#pragma once
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <sigslot/signal.hpp>
+#include <generated/types/cb_board_support.hpp>
+#include "CbTarragonRelay.hpp"
+#include "CbTarragonContactor.hpp"
+
+class CbTarragonContactor {
+
+public:
+    /// @brief Constructor.
+    /// @param name An description, eg. a simple "Contactor" or "Primary contactor"...
+    /// @param relay A pointer to an instance of CbTarragonRelay.
+    /// @param contactor_feedback_type Defines the logic behind the feedback (no = normally open, nc = normally close,
+    /// none = no feedback).
+    CbTarragonContactor(const std::string& name, std::unique_ptr<CbTarragonRelay> relay,
+                        const std::string& contactor_feedback_type);
+
+    /// @brief Returns the contactor name
+    /// @return The contactor name
+    const std::string& get_name() const;
+
+    /// @brief Switch the contactor on/off.
+    /// @param on The target state (true = on, false = off)
+    /// @param wait_for_feedback Tell whether to wait and evaluate the feedback before returning.
+    /// @return Returns true if the new state was reached successfully (based on feedback if configured),
+    /// false otherwise.
+    bool switch_state(bool on, bool wait_for_feedback);
+
+    /// @brief Read the actual state (based on actuator line).
+    bool get_state() const;
+
+    /// @brief Read the actual state (based on feedback).
+    types::cb_board_support::ContactorState get_feedback_state() const;
+
+    /// @brief Check whether the actual feedback state matches the actuator state.
+    /// @return Returns true if there both states differ, false otherwise.
+    bool is_state_mismatch() const;
+
+    /// @brief Tell the relay's feedback monitoring about an expected change which is not initiated by
+    ///        ourself, e.g. because of a special serial wiring of multiple contactors.
+    void set_expected_feedback_change(bool on);
+
+    /// @brief Return the time to wait until the contactor can be closed again.
+    std::chrono::milliseconds get_closing_delay_left() const;
+
+    /// @brief Signal used to inform about unexpected state changes on the feedback contact.
+    sigslot::signal<const std::string, types::cb_board_support::ContactorState> on_unexpected_change;
+
+    /// @brief Feeds a string representation of the given CbTarragonContactorControlSimple
+    ///        instance into an output stream.
+    /// @return A reference to the output stream operated on.
+    friend std::ostream& operator<<(std::ostream& os, const CbTarragonContactor& c);
+
+private:
+    /// @brief Stores the contactor description
+    std::string name;
+
+    /// @brief The feedback type used.
+    types::cb_board_support::ContactorFeedbackType feedback_type;
+
+    /// @brief The relay used to control the contactor and to evaluate the feedback (if used).
+    std::unique_ptr<CbTarragonRelay> relay;
+};

--- a/modules/CbTarragonDriver/tarragon/CbTarragonContactorControl.cpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonContactorControl.cpp
@@ -9,7 +9,13 @@
 using namespace std::chrono_literals;
 
 bool CbTarragonContactorControl::switch_contactor(CbTarragonContactor& contactor, bool on, bool wait_for_feedback) {
-    bool rv = contactor.switch_state(on, wait_for_feedback);
+    bool rv;
+
+    // reject power on in case emergency flag is set
+    if (this->is_emergency && on)
+        return false;
+
+    rv = contactor.switch_state(on, wait_for_feedback);
 
     if (!rv) {
         // Note: we failed to switch, that means we've 'seen' still the old state

--- a/modules/CbTarragonDriver/tarragon/CbTarragonContactorControl.cpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonContactorControl.cpp
@@ -1,312 +1,40 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright chargebyte GmbH and Contributors to EVerest
 #include <chrono>
-#include <optional>
 #include <string>
-#include <gpiod.hpp>
-#include <everest/logging.hpp>
-#include <iostream>
+#include <sigslot/signal.hpp>
+#include "CbTarragonContactor.hpp"
 #include "CbTarragonContactorControl.hpp"
 
-CbTarragonContactorControl::CbTarragonContactorControl(void) {
-}
+using namespace std::chrono_literals;
 
-CbTarragonContactorControl::CbTarragonContactorControl(
-    const std::string& relay_1_name, const std::string& relay_1_actuator_gpio_line_name,
-    const std::string& relay_1_feedback_gpio_line_name, const unsigned int relay_1_gpio_debounce_us,
-    const std::string& contactor_1_feedback_type, const std::string& relay_2_name,
-    const std::string& relay_2_actuator_gpio_line_name, const std::string& relay_2_feedback_gpio_line_name,
-    const unsigned int relay_2_gpio_debounce_us, const std::string& contactor_2_feedback_type,
-    bool switch_3ph1ph_enabled) :
-    relay_1(relay_1_name, relay_1_actuator_gpio_line_name, contactor_1_feedback_type, relay_1_feedback_gpio_line_name,
-            relay_1_gpio_debounce_us),
-    contactor_1_feedback_type(contactor_1_feedback_type) {
+bool CbTarragonContactorControl::switch_contactor(CbTarragonContactor& contactor, bool on, bool wait_for_feedback) {
+    bool rv = contactor.switch_state(on, wait_for_feedback);
 
-    EVLOG_info << "Primary contactor feedback type: '" << this->contactor_1_feedback_type << "'";
+    if (!rv) {
+        // Note: we failed to switch, that means we've 'seen' still the old state
+        types::cb_board_support::ContactorState actual_contactor_state {
+            on ? types::cb_board_support::ContactorState::Open : types::cb_board_support::ContactorState::Closed};
 
-    if (this->contactor_1_feedback_type == "none")
-        EVLOG_warning << "The primary contactor has the feedback pin not connected. This is not recommended.";
-
-    // only instantiate the second relay if the user actually wants to use phase-switching
-    // (it might happen that the second relay would be used for other purposes which
-    // should be handled by another piece of software then)
-    if (switch_3ph1ph_enabled) {
-        this->relay_2 = CbTarragonRelay(relay_2_name, relay_2_actuator_gpio_line_name, contactor_2_feedback_type,
-                                        relay_2_feedback_gpio_line_name, relay_2_gpio_debounce_us);
-
-        this->contactor_2_feedback_type = contactor_2_feedback_type;
-        EVLOG_info << "Secondary contactor feedback type: '" << this->contactor_2_feedback_type << "'";
-
-        if (this->contactor_2_feedback_type == "none")
-            EVLOG_warning << "The secondary contactor has the feedback pin not connected. This is not recommended.";
+        this->on_error(contactor.get_name(), on, actual_contactor_state);
     }
 
-    // if phase-count switching is enabled, we default to 3-phase operation
-    this->target_phase_count = switch_3ph1ph_enabled ? 3 : 1;
-
-    // initialize the actual state by reading the GPIO feedback
-    this->actual_state = this->get_current_state();
-    // the state must be OPEN
-    if (this->actual_state != ContactorState::CONTACTOR_OPEN)
-        EVLOG_error << "Contactor is not in OPEN state during initialization";
-
-    this->new_target_state_ts = std::chrono::steady_clock::now();
-    this->is_new_target_state_set = false;
-
-    this->last_actual_state_open_ts = std::chrono::steady_clock::now();
-    this->delay_contactor_close = false;
-
-    // making sure that we have no contactor errors by forcing a safe initial state
-    this->set_target_state(ContactorState::CONTACTOR_OPEN);
+    return rv;
 }
 
-ContactorState CbTarragonContactorControl::get_current_state() {
-    if (this->target_phase_count == 1) {
-        // when target_phase_count == 1 then this means that we either want to switch only
-        // a single phase, or we don't have phase-count switching setup at all;
-        // but in a phase-count switching setup, we want to ensure that only the primary
-        // contactor is closed so in case the secondary is also closed report CONTACTOR_UNKNOWN
-        if (this->relay_2.has_value() && this->relay_2.value().get_feedback_state())
-            return ContactorState::CONTACTOR_UNKNOWN;
-
-        return this->relay_1.get_feedback_state() ? ContactorState::CONTACTOR_CLOSED : ContactorState::CONTACTOR_OPEN;
-    }
-
-    // reaching this line means: phase-count switching setup
-    // so not having the second relay configured is error -> report as UNKNOWN
-    if (!this->relay_2.has_value())
-        return ContactorState::CONTACTOR_UNKNOWN;
-
-    return (this->relay_1.get_feedback_state() && this->relay_2.value().get_feedback_state())
-               ? ContactorState::CONTACTOR_CLOSED
-               : ContactorState::CONTACTOR_OPEN;
-}
-
-ContactorState CbTarragonContactorControl::get_state(StateType state) const {
-    if (state == StateType::ACTUAL_STATE)
-        return this->actual_state;
-    else if (state == StateType::TARGET_STATE)
-        return this->target_state;
-
-    return ContactorState::CONTACTOR_UNKNOWN;
-}
-
-void CbTarragonContactorControl::set_target_state(ContactorState target_state) {
-    bool actuator_target_state = (target_state == ContactorState::CONTACTOR_CLOSED ? 1 : 0);
-    this->target_state = target_state;
-
-    if ((this->actual_state == this->target_state) && (this->target_state != ContactorState::CONTACTOR_OPEN))
-        return;
-
-    // avoid very fast switching in order to ensure internal relay lifetime
-    if ((this->target_state == ContactorState::CONTACTOR_CLOSED) && (this->is_switch_on_allowed() == false)) {
-
-        auto elapsed_time = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
-                                                                                  this->get_last_actual_state_open_ts())
-                                .count();
-        auto remaining_time = this->relay_1.get_contactor_close_interval() -
-                              std::chrono::duration_cast<std::chrono::milliseconds>(
-                                  std::chrono::steady_clock::now() - this->get_last_actual_state_open_ts());
-
-        EVLOG_warning << "Attempt to close contactor within " << elapsed_time
-                      << " ms from last CLOSED state! Delay for " << remaining_time.count() << " ms";
-        this->delay_contactor_close = true;
-        return;
-    }
-
-    // capture the timestamp of the new actuator target state
-    this->new_target_state_ts = std::chrono::steady_clock::now();
-    this->is_new_target_state_set = true;
-
-    // switching 2nd relay in the following is only required when phase-count switching is enabled
-    // and this usually requires the relay 2 to be present - however, we can check anyway
-
-    switch (this->target_state) {
-    case ContactorState::CONTACTOR_OPEN:
-        // relay 1 must be opened first
-        this->relay_1.set_actuator_state(actuator_target_state);
-
-        // then we can also relay 2
-        if (this->relay_2.has_value())
-            this->relay_2.value().set_actuator_state(actuator_target_state);
-
-        break;
-
-    case ContactorState::CONTACTOR_CLOSED:
-        // closing relay 2 first is important
-        if (this->target_phase_count == 3 && this->relay_2.has_value())
-            this->relay_2.value().set_actuator_state(actuator_target_state);
-
-        // then close relay 1
-        this->relay_1.set_actuator_state(actuator_target_state);
-
-        break;
-
-    default:
-        // should not happen
-        ;
-    }
-}
-
-void CbTarragonContactorControl::set_actual_state(ContactorState actual_state) {
-    this->actual_state = actual_state;
-
-    // update the new phase count
-    this->update_actual_phase_count();
-
-    // handle prevention of relay wear by capturing the timestamp of the last relay OPEN state
-    if (this->actual_state == ContactorState::CONTACTOR_OPEN) {
-        if ((this->target_phase_count == 3) && this->relay_2.has_value()) {
-            this->relay_2.value().set_last_contactor_open_ts(std::chrono::steady_clock::now());
-            this->relay_2.value().set_delay_contactor_close(true);
-        }
-
-        this->relay_1.set_last_contactor_open_ts(std::chrono::steady_clock::now());
-        this->relay_1.set_delay_contactor_close(true);
-
-        this->last_actual_state_open_ts = std::chrono::steady_clock::now();
-    }
-}
-
-void CbTarragonContactorControl::update_actual_phase_count() {
-    bool relay_1_feedback_state = this->relay_1.get_feedback_state();
-    bool relay_2_feedback_state = this->relay_2.has_value() ? this->relay_2.value().get_feedback_state() : false;
-
-    if (relay_1_feedback_state == false && relay_2_feedback_state == false)
-        this->actual_phase_count = 0;
-
-    if (relay_1_feedback_state == true && relay_2_feedback_state == false)
-        this->actual_phase_count = 1;
-
-    if (relay_1_feedback_state == true && relay_2_feedback_state == true)
-        this->actual_phase_count = 3;
-}
-
-int CbTarragonContactorControl::get_actual_phase_count() const {
-    return this->actual_phase_count;
-}
-
-int CbTarragonContactorControl::get_target_phase_count() const {
-    return this->target_phase_count;
+bool CbTarragonContactorControl::open() {
+    return this->switch_state(false);
 }
 
 void CbTarragonContactorControl::switch_phase_count(bool use_3phases) {
-    if (this->relay_2.has_value() && use_3phases)
-        this->target_phase_count = 3;
-    else
-        this->target_phase_count = 1;
+    this->phase_count = use_3phases ? 3 : 1;
 }
 
-std::chrono::time_point<std::chrono::steady_clock> CbTarragonContactorControl::get_new_target_state_ts() const {
-    return this->new_target_state_ts;
-}
-
-bool CbTarragonContactorControl::get_is_new_target_state_set() const {
-    return this->is_new_target_state_set;
-}
-
-void CbTarragonContactorControl::reset_is_new_target_state_set() {
-    this->is_new_target_state_set = false;
-}
-
-std::chrono::time_point<std::chrono::steady_clock> CbTarragonContactorControl::get_last_actual_state_open_ts() const {
-    return this->last_actual_state_open_ts;
-}
-
-bool CbTarragonContactorControl::is_switch_on_allowed() {
-    bool allowed {true};
-
-    // avoid very fast switching in order to ensure internal relay lifetime
-    if ((this->target_phase_count == 3) && this->relay_2.has_value() &&
-        (this->relay_2.value().can_close_contactor() == false))
-        allowed = false;
-
-    if (this->relay_1.can_close_contactor() == false)
-        allowed = false;
-
-    return allowed;
-}
-
-bool CbTarragonContactorControl::get_delay_contactor_close() const {
-    return this->delay_contactor_close;
-}
-
-void CbTarragonContactorControl::reset_delay_contactor_close() {
-    this->delay_contactor_close = false;
-}
-
-bool CbTarragonContactorControl::is_error_state() const {
-    if (this->actual_state != this->target_state)
-        return true;
-
-    return false;
-}
-
-bool CbTarragonContactorControl::wait_for_events(std::chrono::milliseconds duration) {
-    bool event_occurred = false;
-
-    if (this->target_phase_count == 3 && this->contactor_2_feedback_type != "none") {
-        event_occurred =
-            this->relay_2.value().wait_for_feedback(std::chrono::duration_cast<std::chrono::nanoseconds>(duration));
-
-        if (this->contactor_1_feedback_type != "none") {
-            event_occurred &=
-                this->relay_1.wait_for_feedback(std::chrono::duration_cast<std::chrono::nanoseconds>(duration));
-        }
-
-    } else {
-        if (this->contactor_1_feedback_type != "none")
-            event_occurred =
-                this->relay_1.wait_for_feedback(std::chrono::duration_cast<std::chrono::nanoseconds>(duration));
-    }
-
-    return event_occurred;
-}
-
-bool CbTarragonContactorControl::read_events() {
-    gpiod::edge_event::event_type event;
-    bool contactor_state = 0;
-
-    if (this->target_phase_count == 3 && this->contactor_2_feedback_type != "none") {
-        event = this->relay_2.value().read_feedback_event();
-        contactor_state = this->relay_2.value().verify_feedback_event(event);
-
-        if (this->contactor_1_feedback_type != "none") {
-            event = this->relay_1.read_feedback_event();
-            contactor_state &= this->relay_1.verify_feedback_event(event);
-        }
-
-    } else {
-        if (this->contactor_1_feedback_type != "none") {
-            event = this->relay_1.read_feedback_event();
-            contactor_state = this->relay_1.verify_feedback_event(event);
-        }
-    }
-
-    return contactor_state;
-}
-
-std::ostream& operator<<(std::ostream& os, const ContactorState& state) {
-    switch (state) {
-    case ContactorState::CONTACTOR_CLOSED:
-        os << "CLOSED";
-        break;
-    case ContactorState::CONTACTOR_OPEN:
-        os << "OPEN";
-        break;
-    default:
-        os << "UNKNOWN";
-        break;
-    }
+std::ostream& CbTarragonContactorControl::dump(std::ostream& os) const {
+    os << "CbTarragonContactorControl";
     return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const CbTarragonContactorControl& cc) {
-    ContactorState state{cc.get_state(StateType::ACTUAL_STATE)};
-
-    os << state;
-    if (state == ContactorState::CONTACTOR_CLOSED)
-        os << " (phases: " << cc.get_actual_phase_count() << ")";
-
-    return os;
+std::ostream& operator<<(std::ostream& os, const CbTarragonContactorControl& c) {
+    return c.dump(os);
 }

--- a/modules/CbTarragonDriver/tarragon/CbTarragonContactorControl.hpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonContactorControl.hpp
@@ -54,6 +54,11 @@ public:
     /// @brief Signal used to inform about unexpected state changes on the feedback GPIO(s).
     sigslot::signal<const std::string&, types::cb_board_support::ContactorState> on_unexpected_change;
 
+    /// @brief Remembers whether an emergency state was detected and thus contactor closing must be prevented.
+    ///        This could e.g. be RCD error. It should be true as long as an emergency state is present,
+    ///        false otherwise.
+    std::atomic_bool is_emergency {false};
+
     /// @brief Feeds a string representation of the given CbTarragonContactorControl
     ///        instance into an output stream.
     /// @return A reference to the output stream operated on.

--- a/modules/CbTarragonDriver/tarragon/CbTarragonContactorControl.hpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonContactorControl.hpp
@@ -2,187 +2,77 @@
 // Copyright chargebyte GmbH and Contributors to EVerest
 #pragma once
 #include <chrono>
-#include <optional>
+#include <sstream>
 #include <string>
-#include <iostream>
-#include "CbTarragonRelay.hpp"
-
-/// @brief Class representing the 2 possible contactor states.
-enum class ContactorState {
-    CONTACTOR_UNKNOWN,
-    CONTACTOR_OPEN,
-    CONTACTOR_CLOSED
-};
-
-/// @brief Writes the string representation of the given ContactorState to the given
-///        output stream os.
-/// @return an output stream with the state written to
-std::ostream& operator<<(std::ostream& os, const ContactorState& state);
-
-/// @brief Class representing the different state types.
-enum class StateType {
-    ACTUAL_STATE,
-    TARGET_STATE
-};
+#include <sigslot/signal.hpp>
+#include <generated/types/cb_board_support.hpp>
+#include "CbTarragonContactor.hpp"
 
 ///
-/// This class abstracts the control of the two relays on the Tarragon platform. Each relay controls
-/// the opening or closing of a contactor in a charging station, and the feedback representing the state of
-/// the contactor can be read and analyzed through the board. This class simplifies the relay control,
-/// allowing for handling both single and three-phase operations.
-/// For phase-count switching setups, only the so called 'serial' wiring setup is supported.
-/// This means, that the primary contactor (controlled via relay 1) either switches all 3 phases or
-/// at least the first one, and the secondary contactor switches phase 2 and 3. But the important aspect
-/// here is that the secondary contactor is first switched on, and switched off last, while the primary
-/// contactor is switched on last, and switched off first. The sequence is required to present a consistent
-/// "these phases are available" view to the car - in other words, the phases do not arrive with a
-/// time lag at the car.
-/// Note on the implementation: in case phase-count switching is not enabled, we internally handle this
-/// as single phase mode (because in this case, the real-world number of phases does not matter).
+/// This is an "abstract" (not in sense of C++ meaning) class for handling contactor control.
+/// It only defines the interface which is used by the upper layer.
+/// Derived classes implement specific contactor handling setups.
 ///
 class CbTarragonContactorControl {
 
 public:
-    /// @brief Default constructor.
-    CbTarragonContactorControl(void);
-
     /// @brief Constructor.
-    /// @param relay_1_name The name of the first relay and its feedback as labeled on hardware.
-    /// @param relay_1_actuator_gpio_line_name The name of the GPIO line which switches the first relay on/off.
-    /// @param relay_1_feedback_gpio_line_name The name of the GPIO line to which the feedback/sense signal of relay 1
-    /// is connected to.
-    /// @param relay_1_feedback_gpio_deboucne_us The debounce period which should be configured on the GPIO line in
-    /// microseconds. Pass zero to skip the configuration of any debounce period.
-    /// @param contactor_1_feedback_type Defines the logic behind the feedback (no = normally open, nc = normally close,
-    /// none = no feedback).
-    /// @param relay_2_name The name of the second relay and its feedback as labeled on hardware.
-    /// @param relay_2_actuator_gpio_line_name The name of the GPIO line which switches the second relay on/off.
-    /// @param relay_2_feedback_gpio_line_name The name of the GPIO line to which the feedback/sense signal of relay 2
-    /// is connected to.
-    /// @param relay_2_feedback_gpio_deboucne_us The debounce period which should be configured on the GPIO line in
-    /// microseconds. Pass zero to skip the configuration of any debounce period.
-    /// @param contactor_2_feedback_type Defines the logic behind the feedback (no = normally open, nc = normally close,
-    /// none = no feedback).
-    /// @param switch_3ph1ph_enabled True whether relay 2 should be used for phase switching, relay 2 is ignored
-    /// otherwise.
-    CbTarragonContactorControl(const std::string& relay_1_name, const std::string& relay_1_actuator_gpio_line_name,
-                               const std::string& relay_1_feedback_gpio_line_name,
-                               const unsigned int relay_1_gpio_debounce_us,
-                               const std::string& contactor_1_feedback_type, const std::string& relay_2_name,
-                               const std::string& relay_2_actuator_gpio_line_name,
-                               const std::string& relay_2_feedback_gpio_line_name,
-                               const unsigned int relay_2_gpio_debounce_us,
-                               const std::string& contactor_2_feedback_type, bool switch_3ph1ph_enabled);
+    CbTarragonContactorControl() {};
 
-    /// @brief Get the state of one or both contactors ('actual' or 'target').
-    ContactorState get_state(StateType state) const;
+    /// @brief Checks the actual states of actuator and feedback for plausibility.
+    ///        This is intended to be called once during startup only, since
+    ///        error reporting is limited during this phase.
+    /// @param[out] error_hint A string with a user hint which looks unexpected.
+    /// @return True in case there is an unexpected state detected, false otherwise.
+    virtual bool is_inconsistent_state(std::ostringstream& error_hint) const = 0;
 
-    /// @brief Set the target state of one or both contactors.
-    /// @param target_state The desired contactor state (OPEN or CLOSED).
-    void set_target_state(ContactorState target_state);
+    /// @brief Closes the contactor (on = true), or opens it (on = false):
+    ///        This is a synchronous call, i.e. it waits until it is confirmed
+    ///        by feedback signal (if used). It also waits the required time
+    ///        in case the relay is protected by a maximum switching time to
+    ///        prevent wear out.
+    /// @return True on success, false on error.
+    virtual bool switch_state(bool on) = 0;
 
-    /// @brief Set the actual observed state of the contactor(s).
-    /// @param actual_state The observed contactor state (OPEN or CLOSED).
-    void set_actual_state(ContactorState actual_state);
+    /// @brief Opens the contactor. Convenience helper just for code readability.
+    /// @return True on success, false on error.
+    bool open();
 
-    /// @brief Update the number of phases in operation.
-    void update_actual_phase_count();
+    /// @brief Return the current state of the contactor based on the actuator line.
+    /// @return True when contactor is closed, false otherwise.
+    virtual bool get_state() const = 0;
 
-    /// @brief Get the number of phases in operation.
-    /// @return number of phases
-    ///         (0 = Error: no phases in operation, 1 = 1-phase, 3 = 3-phase).
-    int get_actual_phase_count() const;
+    /// @brief Return the time to wait until the relay can be closed again.
+    virtual std::chrono::milliseconds get_closing_delay_left() const = 0;
 
-    /// @brief Get the target number of phases.
-    /// @return number of phases
-    ///         (1 = 1-phase, 3 = 3-phase).
-    int get_target_phase_count() const;
-
-    /// @brief Switch between 3-phase and 1-phase operation mode.
-    /// @param use_3phases True if 3 phases shall be used, false otherwise.
+    /// @brief Set the desired count of phases for next contactor closing.
     void switch_phase_count(bool use_3phases);
 
-    /// @brief Return the timestamp at which a new state was set to the actuator
-    std::chrono::time_point<std::chrono::steady_clock> get_new_target_state_ts() const;
+    /// @brief Signal used to inform about errors during switching.
+    sigslot::signal<const std::string&, bool, types::cb_board_support::ContactorState> on_error;
 
-    /// @brief Return the status of the flag marking the start of observation
-    ///        of the timestamp at which a new state was set to the actuator.
-    bool get_is_new_target_state_set() const;
+    /// @brief Signal used to inform about unexpected state changes on the feedback GPIO(s).
+    sigslot::signal<const std::string&, types::cb_board_support::ContactorState> on_unexpected_change;
 
-    /// @brief Reset the flag is_new_target_state_set.
-    void reset_is_new_target_state_set();
+    /// @brief Feeds a string representation of the given CbTarragonContactorControl
+    ///        instance into an output stream.
+    /// @return A reference to the output stream operated on.
+    friend std::ostream& operator<<(std::ostream& os, const CbTarragonContactorControl& c);
 
-    /// @brief Return the timestamp at which last actual state change from closed to
-    ///        open has occurred.
-    std::chrono::time_point<std::chrono::steady_clock> get_last_actual_state_open_ts() const;
-
-    /// @brief Determine if switching on is allowed or not to prevent relay wear.
-    /// @Return `true` if switch on allowed, `false` otherwise.
-    bool is_switch_on_allowed();
-
-    /// @brief Return the value of the flag delay_contactor_close.
-    bool get_delay_contactor_close() const;
-
-    /// @brief Reset the flag delay_contactor_close.
-    void reset_delay_contactor_close();
-
-    /// @brief Determine if there exists contactor(s) error (0 or 1).
-    bool is_error_state() const;
-
-    /// @brief Wait for new events (GPIO interrupts) occurring on the relays feedback.
-    /// @param duration The maximum duration to wait for events to occur.
-    /// @return '0' if no events, '1' if events occurred.
-    bool wait_for_events(std::chrono::milliseconds duration);
-
-    /// @brief Wait for new events (GPIO interrupts) occurring on the relays feedback.
-    /// @return '0' it is a contactor opened event, '1' if it is a contactor closed event.
-    bool read_events();
-
-private:
-    /// @brief Object representing the first relay on the Tarragon board.
-    CbTarragonRelay relay_1;
-
-    /// @brief Object representing the second relay on the Tarragon board.
-    ///        This is optional as it might happen that the second relay is
-    ///        used for other purposes other than 3-phase operation.
-    std::optional<CbTarragonRelay> relay_2;
-
-    /// @brief nc = normally close, no = normally open, none = no feedback.
-    std::string contactor_1_feedback_type;
-
-    /// @brief nc = normally close, no = normally open, none = no feedback.
-    std::string contactor_2_feedback_type;
-
-    /// @brief Actual state of the contactor(s).
-    ContactorState actual_state;
-
-    /// @brief Target state of the contactor(s).
-    ContactorState target_state;
-
-    /// @brief Number of phases in operation (1 or 3).
-    int actual_phase_count {0};
-
+protected:
     /// @brief Desired number of phases (1 or 3).
-    int target_phase_count {3};
+    int phase_count {3};
 
-    /// @brief Timestamp at which a new state was set to the actuator.
-    std::chrono::time_point<std::chrono::steady_clock> new_target_state_ts;
+    /// @brief Helper which switches the given contactor and reports an error if
+    ///        the switching failed.
+    /// @param contactor Reference to the contactor instance to operate on.
+    /// @param on The target state (true = on, false = off)
+    /// @param wait_for_feedback Tell whether to wait and evaluate the feedback before returning.
+    /// @return True on success, false on error.
+    bool switch_contactor(CbTarragonContactor& contactor, bool on, bool wait_for_feedback = true);
 
-    /// @brief Flag to mark the start of observation of the timestamp
-    ///        at which a new state was set to the actuator.
-    bool is_new_target_state_set;
-
-    /// @brief Timestamp of the last actual state change from closed to open.
-    std::chrono::time_point<std::chrono::steady_clock> last_actual_state_open_ts;
-
-    /// @brief Flag to determine if closing the contactor should be delayed.
-    bool delay_contactor_close;
-
-    /// @brief Return current state based on evaluation of current GPIOs.
-    ContactorState get_current_state();
+    /// @brief Helper to feed a string representation into an output stream.
+    /// @param os Output stream reference to operate on.
+    /// @return A reference to the output stream operated on.
+    virtual std::ostream& dump(std::ostream& os) const;
 };
-
-/// @brief Feeds a string representation of the given CbTarragonContactorControl
-///        instance into an output stream.
-/// @return A reference to the output stream operated on.
-std::ostream& operator<<(std::ostream& os, const CbTarragonContactorControl& cc);

--- a/modules/CbTarragonDriver/tarragon/CbTarragonContactorControlMutual.cpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonContactorControlMutual.cpp
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright chargebyte GmbH and Contributors to EVerest
+#include <chrono>
+#include <iostream>
+#include <string>
+#include "CbTarragonContactor.hpp"
+#include "CbTarragonContactorControl.hpp"
+#include "CbTarragonContactorControlMutual.hpp"
+#include <everest/logging.hpp>
+
+CbTarragonContactorControlMutual::CbTarragonContactorControlMutual(std::unique_ptr<CbTarragonRelay> relay_3ph,
+                                                                   const std::string& contactor_3ph_feedback_type,
+                                                                   std::unique_ptr<CbTarragonRelay> relay_1ph,
+                                                                   const std::string& contactor_1ph_feedback_type) :
+    contactor_3ph("3ph Contactor", std::move(relay_3ph), contactor_3ph_feedback_type),
+    contactor_1ph("1ph Contactor", std::move(relay_1ph), contactor_1ph_feedback_type) {
+
+    EVLOG_info << this->contactor_3ph.get_name() << " feedback type: '" << contactor_3ph_feedback_type << "'";
+    if (contactor_3ph_feedback_type == "none")
+        EVLOG_warning << "The " << this->contactor_3ph.get_name()
+                      << " has the feedback pin not connected. This is not recommended.";
+
+    EVLOG_info << this->contactor_1ph.get_name() << " feedback type: '" << contactor_1ph_feedback_type << "'";
+    if (contactor_1ph_feedback_type == "none")
+        EVLOG_warning << "The " << this->contactor_1ph.get_name()
+                      << " has the feedback pin not connected. This is not recommended.";
+
+    this->contactor_3ph.on_unexpected_change.connect(
+        [&](const std::string& contactor_name, types::cb_board_support::ContactorState seen_contactor_state) {
+            this->on_unexpected_change(contactor_name, seen_contactor_state);
+        });
+
+    this->contactor_1ph.on_unexpected_change.connect(
+        [&](const std::string& contactor_name, types::cb_board_support::ContactorState seen_contactor_state) {
+            this->on_unexpected_change(contactor_name, seen_contactor_state);
+        });
+}
+
+bool CbTarragonContactorControlMutual::is_inconsistent_state(std::ostringstream& error_hint) const {
+    if (this->contactor_3ph.is_state_mismatch()) {
+        error_hint << this->contactor_3ph;
+        return true;
+    }
+
+    if (this->contactor_1ph.is_state_mismatch()) {
+        error_hint << this->contactor_1ph;
+        return true;
+    }
+
+    return false;
+}
+
+bool CbTarragonContactorControlMutual::switch_state(bool on) {
+    if (this->phase_count == 3)
+        return this->switch_contactor(this->contactor_3ph, on);
+    else
+        return this->switch_contactor(this->contactor_1ph, on);
+}
+
+bool CbTarragonContactorControlMutual::get_state() const {
+    // we can combine both states by OR-ing
+    return this->contactor_3ph.get_state() or this->contactor_1ph.get_state();
+}
+
+std::chrono::milliseconds CbTarragonContactorControlMutual::get_closing_delay_left() const {
+    if (this->phase_count == 3)
+        return this->contactor_3ph.get_closing_delay_left();
+    else
+        return this->contactor_1ph.get_closing_delay_left();
+}
+
+std::ostream& CbTarragonContactorControlMutual::dump(std::ostream& os) const {
+    os << this->contactor_3ph << ", " << this->contactor_1ph;
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const CbTarragonContactorControlMutual& c) {
+    return c.dump(os);
+}

--- a/modules/CbTarragonDriver/tarragon/CbTarragonContactorControlMutual.hpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonContactorControlMutual.hpp
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright chargebyte GmbH and Contributors to EVerest
+#pragma once
+#include <chrono>
+#include <memory>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include "CbTarragonContactor.hpp"
+#include "CbTarragonContactorControl.hpp"
+#include "CbTarragonRelay.hpp"
+
+///
+/// This class implements a 'mutual' wiring contactor setup, i.e. with support for phase count switching.
+/// This means, that the first contactor switches all 3 phases and the second contactor switches
+/// only a single phase. Both contactors are used mutually exclusive.
+///
+class CbTarragonContactorControlMutual : public CbTarragonContactorControl {
+
+public:
+    /// @brief Constructor.
+    /// @param relay_3ph A pointer to an instance of CbTarragonRelay.
+    /// @param contactor_3ph_feedback_type Defines the logic behind the feedback of the 3ph contactor (no = normally
+    /// open, nc = normally close, none = no feedback).
+    /// @param relay_1ph A pointer to an instance of CbTarragonRelay.
+    /// @param contactor_1ph_feedback_type Defines the logic behind the feedback of the 1ph contactor (no = normally
+    /// open, nc = normally close, none = no feedback).
+    CbTarragonContactorControlMutual(std::unique_ptr<CbTarragonRelay> relay_3ph,
+                                     const std::string& contactor_3ph_feedback_type,
+                                     std::unique_ptr<CbTarragonRelay> relay_1ph,
+                                     const std::string& contactor_1ph_feedback_type);
+
+    virtual bool is_inconsistent_state(std::ostringstream& error_hint) const override;
+    virtual bool switch_state(bool on) override;
+    virtual bool get_state() const override;
+    virtual std::chrono::milliseconds get_closing_delay_left() const override;
+
+    /// @brief Feeds a string representation of the given CbTarragonContactorControlMutual
+    ///        instance into an output stream.
+    /// @return A reference to the output stream operated on.
+    friend std::ostream& operator<<(std::ostream& os, const CbTarragonContactorControlMutual& c);
+
+private:
+    /// @brief The contactor which switches all 3 phases and its feedback abstraction.
+    CbTarragonContactor contactor_3ph;
+
+    /// @brief The contactor which switches only 1 phase and its feedback abstraction.
+    CbTarragonContactor contactor_1ph;
+
+    /// @brief Helper to feed a string representation into an output stream.
+    /// @param os Output stream reference to operate on.
+    /// @return A reference to the output stream operated on.
+    virtual std::ostream& dump(std::ostream& os) const override;
+};

--- a/modules/CbTarragonDriver/tarragon/CbTarragonContactorControlSerial.cpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonContactorControlSerial.cpp
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright chargebyte GmbH and Contributors to EVerest
+#include <chrono>
+#include <iostream>
+#include <string>
+#include "CbTarragonContactor.hpp"
+#include "CbTarragonContactorControl.hpp"
+#include "CbTarragonContactorControlSerial.hpp"
+#include <everest/logging.hpp>
+
+CbTarragonContactorControlSerial::CbTarragonContactorControlSerial(
+    std::unique_ptr<CbTarragonRelay> primary_relay, const std::string& primary_contactor_feedback_type,
+    std::unique_ptr<CbTarragonRelay> secondary_relay, const std::string& secondary_contactor_feedback_type) :
+    primary("Primary Contactor", std::move(primary_relay), primary_contactor_feedback_type),
+    secondary("Secondary Contactor", std::move(secondary_relay), secondary_contactor_feedback_type) {
+
+    EVLOG_info << this->primary.get_name() << " feedback type: '" << primary_contactor_feedback_type << "'";
+    if (primary_contactor_feedback_type == "none")
+        EVLOG_warning << "The " << this->primary.get_name()
+                      << " has the feedback pin not connected. This is not recommended.";
+
+    EVLOG_info << this->secondary.get_name() << " feedback type: '" << secondary_contactor_feedback_type << "'";
+    if (secondary_contactor_feedback_type == "none")
+        EVLOG_warning << "The " << this->secondary.get_name()
+                      << " has the feedback pin not connected. This is not recommended.";
+
+    this->primary.on_unexpected_change.connect(
+        [&](const std::string& contactor_name, types::cb_board_support::ContactorState seen_contactor_state) {
+            this->on_unexpected_change(contactor_name, seen_contactor_state);
+        });
+
+    this->secondary.on_unexpected_change.connect(
+        [&](const std::string& contactor_name, types::cb_board_support::ContactorState seen_contactor_state) {
+            this->on_unexpected_change(contactor_name, seen_contactor_state);
+        });
+}
+
+bool CbTarragonContactorControlSerial::is_inconsistent_state(std::ostringstream& error_hint) const {
+    bool rv;
+
+    rv = this->primary.is_state_mismatch();
+    if (rv) {
+        error_hint << this->primary;
+        return rv;
+    }
+
+    rv = this->secondary.is_state_mismatch();
+    if (rv) {
+        error_hint << this->secondary;
+        return rv;
+    }
+
+    return false;
+}
+
+bool CbTarragonContactorControlSerial::switch_state(bool on) {
+    bool rv_primary, rv_secondary;
+
+    // when closing, we have to consider the secondary first
+    // Attention: we might see the feedback of the secondary first, when
+    // the primary is switched!
+    if (on) {
+        if (this->phase_count == 3) {
+            // don't wait here for the immediate feedback
+            this->switch_contactor(this->secondary, on, false);
+        }
+
+        rv_primary = this->switch_contactor(this->primary, on);
+
+        // now the secondary contactor should have also switched
+        if (this->phase_count == 3) {
+            rv_secondary = this->secondary.get_feedback_state() == types::cb_board_support::ContactorState::Closed;
+        } else {
+            // not switched, so must be neutral for following and-condition in return
+            rv_secondary = true;
+        }
+
+        return rv_primary and rv_secondary;
+    }
+
+    // when opening, we can always switch both contactors in the correct sequence;
+    // here too, we might see the feedback of the secondary already when switching
+    // the primary;
+    // we also do not exit immediately in case of an error when switching the primary
+    // but try at least to switch the secondary - depending on the actual wiring,
+    // this could at least switch off phases 2 and 3 even if the primary contactor
+    // was welded
+
+    // tell the secondary about a possible switch - this can only happen in 3ph mode
+    // otherwise the secondary would/should be open already
+    if (this->phase_count == 3)
+        this->secondary.set_expected_feedback_change(on);
+
+    // Warning: Do not combine both calls via 'and' otherwise the compiler could
+    // short-circuit the expression!
+    rv_primary = this->switch_contactor(this->primary, on);
+    rv_secondary = this->switch_contactor(this->secondary, on);
+
+    return rv_primary and rv_secondary;
+}
+
+bool CbTarragonContactorControlSerial::get_state() const {
+    // it is sufficient to check the primary contactor here
+    return this->primary.get_state();
+}
+
+std::chrono::milliseconds CbTarragonContactorControlSerial::get_closing_delay_left() const {
+    // since we always switch the primary contactor but sometimes the secondary not,
+    // we can just look at the primary -> it covers the secondary completely
+    return this->primary.get_closing_delay_left();
+}
+
+std::ostream& CbTarragonContactorControlSerial::dump(std::ostream& os) const {
+    os << this->primary << ", " << this->secondary;
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const CbTarragonContactorControlSerial& c) {
+    return c.dump(os);
+}

--- a/modules/CbTarragonDriver/tarragon/CbTarragonContactorControlSerial.hpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonContactorControlSerial.hpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright chargebyte GmbH and Contributors to EVerest
+#pragma once
+#include <chrono>
+#include <memory>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include "CbTarragonContactor.hpp"
+#include "CbTarragonContactorControl.hpp"
+#include "CbTarragonRelay.hpp"
+
+///
+/// This class implements a 'serial' wiring contactor setup, i.e. with support for phase count switching.
+/// This means, that the primary contactor either switches all 3 phases or at least the first one,
+/// and the secondary contactor switches phase 2 and 3. But the important aspect here is that the
+/// secondary contactor is first switched on, and switched off last, while the primary contactor is
+/// switched on last, and switched off first. The sequence is required to present a consistent
+/// "these phases are available" view to the car - in other words, the phases do not arrive with
+/// a time lag at the car.
+///
+class CbTarragonContactorControlSerial : public CbTarragonContactorControl {
+
+public:
+    /// @brief Constructor.
+    /// @param primary_relay A pointer to an instance of CbTarragonRelay.
+    /// @param primary_contactor_feedback_type Defines the logic behind the feedback of the primary contactor (no =
+    /// normally open, nc = normally close, none = no feedback).
+    /// @param secondary_relay A pointer to an instance of CbTarragonRelay.
+    /// @param secondary_contactor_feedback_type Defines the logic behind the feedback of the secondary contactor (no =
+    /// normally open, nc = normally close, none = no feedback).
+    CbTarragonContactorControlSerial(std::unique_ptr<CbTarragonRelay> primary_relay,
+                                     const std::string& primary_contactor_feedback_type,
+                                     std::unique_ptr<CbTarragonRelay> secondary_relay,
+                                     const std::string& secondary_contactor_feedback_type);
+
+    virtual bool is_inconsistent_state(std::ostringstream& error_hint) const override;
+    virtual bool switch_state(bool on) override;
+    virtual bool get_state() const override;
+    virtual std::chrono::milliseconds get_closing_delay_left() const override;
+
+    /// @brief Feeds a string representation of the given CbTarragonContactorControlSerial
+    ///        instance into an output stream.
+    /// @return A reference to the output stream operated on.
+    friend std::ostream& operator<<(std::ostream& os, const CbTarragonContactorControlSerial& c);
+
+private:
+    /// @brief The primary contactor and its feedback abstraction.
+    CbTarragonContactor primary;
+
+    /// @brief The secondary contactor and its feedback abstraction.
+    CbTarragonContactor secondary;
+
+    /// @brief Helper to feed a string representation into an output stream.
+    /// @param os Output stream reference to operate on.
+    /// @return A reference to the output stream operated on.
+    virtual std::ostream& dump(std::ostream& os) const override;
+};

--- a/modules/CbTarragonDriver/tarragon/CbTarragonContactorControlSimple.cpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonContactorControlSimple.cpp
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright chargebyte GmbH and Contributors to EVerest
+#include <chrono>
+#include <iostream>
+#include <string>
+#include "CbTarragonContactor.hpp"
+#include "CbTarragonContactorControl.hpp"
+#include "CbTarragonContactorControlSimple.hpp"
+#include <everest/logging.hpp>
+
+CbTarragonContactorControlSimple::CbTarragonContactorControlSimple(std::unique_ptr<CbTarragonRelay> relay,
+                                                                   const std::string& contactor_feedback_type) :
+    contactor("Contactor", std::move(relay), contactor_feedback_type) {
+
+    EVLOG_info << this->contactor.get_name() << " feedback type: '" << contactor_feedback_type << "'";
+    if (contactor_feedback_type == "none")
+        EVLOG_warning << "The contactor has the feedback pin not connected. This is not recommended.";
+
+    this->contactor.on_unexpected_change.connect(
+        [&](const std::string& contactor_name, types::cb_board_support::ContactorState seen_contactor_state) {
+            this->on_unexpected_change(contactor_name, seen_contactor_state);
+        });
+}
+
+bool CbTarragonContactorControlSimple::is_inconsistent_state(std::ostringstream& error_hint) const {
+    bool rv = this->contactor.is_state_mismatch();
+
+    if (rv)
+        error_hint << this->contactor;
+
+    return rv;
+}
+
+bool CbTarragonContactorControlSimple::switch_state(bool on) {
+    return this->switch_contactor(this->contactor, on);
+}
+
+bool CbTarragonContactorControlSimple::get_state() const {
+    return this->contactor.get_state();
+}
+
+std::chrono::milliseconds CbTarragonContactorControlSimple::get_closing_delay_left() const {
+    return this->contactor.get_closing_delay_left();
+}
+
+std::ostream& CbTarragonContactorControlSimple::dump(std::ostream& os) const {
+    os << this->contactor;
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const CbTarragonContactorControlSimple& c) {
+    return c.dump(os);
+}

--- a/modules/CbTarragonDriver/tarragon/CbTarragonContactorControlSimple.hpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonContactorControlSimple.hpp
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright chargebyte GmbH and Contributors to EVerest
+#pragma once
+#include <chrono>
+#include <memory>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include "CbTarragonContactor.hpp"
+#include "CbTarragonContactorControl.hpp"
+#include "CbTarragonRelay.hpp"
+
+///
+/// This class implements a standard/usual contactor setup, eg. a single contactor
+/// without phase count switching.
+///
+class CbTarragonContactorControlSimple : public CbTarragonContactorControl {
+
+public:
+    /// @brief Constructor.
+    /// @param relay A pointer to an instance of CbTarragonRelay.
+    /// @param contactor_feedback_type Defines the logic behind the feedback (no = normally open, nc = normally close,
+    /// none = no feedback).
+    CbTarragonContactorControlSimple(std::unique_ptr<CbTarragonRelay> relay,
+                                     const std::string& contactor_feedback_type);
+
+    virtual bool is_inconsistent_state(std::ostringstream& error_hint) const override;
+    virtual bool switch_state(bool on) override;
+    virtual bool get_state() const override;
+    virtual std::chrono::milliseconds get_closing_delay_left() const override;
+
+    /// @brief Feeds a string representation of the given CbTarragonContactorControlSimple
+    ///        instance into an output stream.
+    /// @return A reference to the output stream operated on.
+    friend std::ostream& operator<<(std::ostream& os, const CbTarragonContactorControlSimple& c);
+
+private:
+    /// @brief The contactor and it's feedback abstraction.
+    CbTarragonContactor contactor;
+
+    /// @brief Helper to feed a string representation into an output stream.
+    /// @param os Output stream reference to operate on.
+    /// @return A reference to the output stream operated on.
+    virtual std::ostream& dump(std::ostream& os) const override;
+};

--- a/modules/CbTarragonDriver/tarragon/CbTarragonRCM.hpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonRCM.hpp
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright chargebyte GmbH and Contributors to EVerest
 #pragma once
+#include <memory>
 #include <string>
 #include <gpiod.hpp>
-#include <memory>
+#include <sigslot/signal.hpp>
 
 class CbTarragonRCM {
 
@@ -23,6 +24,10 @@ public:
     /// @brief Wait for an RCM event to occur.
     /// @param timeout The maximum time to wait for the event in nanoseconds.
     void wait_for_rcm_event(const std::chrono::nanoseconds& timeout);
+
+    /// @brief Signal used to inform RCM state changes. The passed bool is true if RCM is tripped,
+    ///        false otherwise.
+    sigslot::signal<bool> on_change;
 
 private:
     /// @brief The GPIO handle of the used RCM fault pin.

--- a/modules/CbTarragonDriver/tarragon/CbTarragonRelay.cpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonRelay.cpp
@@ -1,25 +1,28 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright chargebyte GmbH and Contributors to EVerest
+#include <chrono>
 #include <memory>
-#include <stdexcept>
+#include <mutex>
+#include <ostream>
+#include <optional>
+#include <string>
+#include <thread>
+#include <everest/logging.hpp>
 #include <gpiod.hpp>
+#include <sigslot/signal.hpp>
+#include <generated/types/cb_board_support.hpp>
 #include <gpiodUtils.hpp>
 #include "CbTarragonRelay.hpp"
 
 using namespace std::chrono_literals;
 
-CbTarragonRelay::CbTarragonRelay(void) {
-}
-
 CbTarragonRelay::CbTarragonRelay(const std::string& relay_name, const std::string& actuator_gpio_line_name,
-                                 const std::string& feedback_type, const std::string& feedback_gpio_line_name,
-                                 const unsigned int feedback_gpio_debounce_us) {
-    bool actuator_active_low {false};
-    bool feedback_active_low {false};
-
-    this->relay_name = relay_name;
-
-    // check if the name contains the character '/' and find its position. This is done because the
+                                 const std::string& feedback_gpio_line_name,
+                                 const unsigned int feedback_gpio_debounce_us) :
+    relay_name(relay_name),
+    feedback_gpio_line_name(feedback_gpio_line_name),
+    feedback_gpio_debounce_us(feedback_gpio_debounce_us) {
+    // check if the relay name contains the character '/' and find its position. This is done because the
     // kernel throws a warning when a GPIO consumer has '/' in its name.
     size_t pos = this->relay_name.find('/');
 
@@ -27,116 +30,190 @@ CbTarragonRelay::CbTarragonRelay(const std::string& relay_name, const std::strin
     if (pos != std::string::npos)
         this->relay_name.replace(pos, 1, "-");
 
-    this->feedback_type = this->get_feedback_type(feedback_type);
+    // during startup, we don't know when the relay was closed the last time;
+    // in a worst-case scenario, we have a endless loop due to crash, so we
+    // ensure here that the switching delay is respected
+    this->last_closed_ts = std::chrono::steady_clock::now();
 
-    this->delay_contactor_close = false;
-    this->last_contactor_open_ts = std::chrono::steady_clock::now();
-    this->contactor_close_interval = 10s;
+    // instantiate and configure the actuator gpio
+    this->actuator = std::make_unique<gpiod::line_request>(
+        get_gpioline_by_name(actuator_gpio_line_name, "CbTarragonRelay (" + this->relay_name + ", actuator)",
+                             gpiod::line_settings()
+                                 .set_direction(gpiod::line::direction::OUTPUT)
+                                 .set_output_value(gpiod::line::value::INACTIVE)
+                                 .set_active_low(false)));
+}
 
-    // initialize the buffer to be of a capacity '1' so that we read a single event
-    this->feedback_event_buffer = gpiod::edge_event_buffer(1);
+CbTarragonRelay::~CbTarragonRelay() {
+    // tell feedback monitoring thread to exit and not to signal unexpected state changes anymore
+    this->termination_requested = true;
 
-    this->actuator =
-        std::make_unique<gpiod::line_request>(get_gpioline_by_name(actuator_gpio_line_name, this->relay_name,
-                                                                   gpiod::line_settings()
-                                                                       .set_direction(gpiod::line::direction::OUTPUT)
-                                                                       .set_output_value(gpiod::line::value::INACTIVE)
-                                                                       .set_active_low(actuator_active_low)));
+    // safety: explicitly open the relay, but don't wait for any feedback
+    this->set_actuator_state(false, false);
+}
 
-    if (this->feedback_type != CbContactorFeedbackType::NONE) {
+void CbTarragonRelay::start(bool use_feedback, bool active_low) {
+    if (use_feedback) {
+        // instantiate and configure the feedback GPIO
         gpiod::line_settings line_settings;
-
         line_settings.set_direction(gpiod::line::direction::INPUT);
         line_settings.set_edge_detection(gpiod::line::edge::BOTH);
-        line_settings.set_active_low(feedback_active_low);
+        line_settings.set_active_low(active_low);
 
         // passing a debounce interval of zero allows to by-pass the whole configuration
-        if (feedback_gpio_debounce_us) {
-            std::chrono::microseconds period(feedback_gpio_debounce_us);
+        if (this->feedback_gpio_debounce_us) {
+            std::chrono::microseconds period(this->feedback_gpio_debounce_us);
             line_settings.set_debounce_period(period);
         }
 
-        this->feedback = std::make_unique<gpiod::line_request>(
-            get_gpioline_by_name(feedback_gpio_line_name, this->relay_name, line_settings));
+        this->feedback = std::make_unique<gpiod::line_request>(get_gpioline_by_name(
+            this->feedback_gpio_line_name, "CbTarragonRelay (" + this->relay_name + ", sense)", line_settings));
+
+        // start feedback handling thread
+        this->feedback_monitor = std::thread(&CbTarragonRelay::feedback_monitor_worker, this);
     }
 }
 
-void CbTarragonRelay::set_last_contactor_open_ts(std::chrono::time_point<std::chrono::steady_clock> timestamp) {
-    this->last_contactor_open_ts = timestamp;
+void CbTarragonRelay::feedback_monitor_worker() {
+    // we want to process a single event at each iteration
+    gpiod::edge_event_buffer event_buffer(1);
+
+    EVLOG_debug << "feedback_monitor_worker for '" << this->relay_name << "' started";
+
+    while (!this->termination_requested) {
+        // wait for next edge event
+        if (this->feedback->wait_edge_events(this->feedback_timeout)) {
+            std::scoped_lock lock(this->expected_edge_mutex);
+
+            this->feedback->read_edge_events(event_buffer, 1);
+            gpiod::edge_event::event_type ev_type = event_buffer.get_event(0).type();
+
+            // check whether the event was expected...
+            if (this->expected_edge.has_value() and !this->expected_edge_matched.has_value()) {
+                // ...and whether the actual edge matches our expectation
+                this->expected_edge_matched = ev_type == this->expected_edge.value();
+
+                // signal the result to `set_actuator_state`
+                this->cv_expected_edge.notify_one();
+
+                // clear the expected edge
+                this->expected_edge.reset();
+
+                // restart waiting for events
+                continue;
+            }
+
+            // ...otherwise signal unexpected feedback change
+            if (!this->termination_requested)
+                this->on_unexpected_change(this->relay_name, ev_type == gpiod::edge_event::event_type::RISING_EDGE);
+        }
+    }
+
+    EVLOG_debug << "feedback_monitor_worker for '" << this->relay_name << "' stopped";
 }
 
-void CbTarragonRelay::set_delay_contactor_close(bool value) {
-    this->delay_contactor_close = value;
-}
+bool CbTarragonRelay::set_actuator_state(bool on, bool wait_for_feedback) {
+    // Remember the desired switch direction. This must be done outside holding the lock.
+    // Explanation: consider a thread calling set_actuator_state(true), i.e. it wants to
+    // switch the relay on. However, it must wait `min_closing_delay`. Then this thread
+    // may sleep. When during this wait time an emergency event occurs which wants to prevent
+    // switching on the relay, then another thread calls set_actuator_state(false) but
+    // cannot enter the critical section until the sleep of the first thread is over
+    // and the previous call completed. This would result in a short glitch, ie. the first
+    // thread would switch the relay on, then the next thread (emergency call) would
+    // switch it off immediately. To prevent this, the second thread switches the following
+    // variable to false which is then additionally considered by the first thread after the sleep.
+    this->execute_actuator_state_on_switch = on;
 
-bool CbTarragonRelay::can_close_contactor(void) {
-    if (this->delay_contactor_close == false)
-        return true;
+    std::unique_lock<std::mutex> lock(this->expected_edge_mutex);
 
-    if (std::chrono::steady_clock::now() - this->last_contactor_open_ts < this->contactor_close_interval)
+    // check whether we need to sleep and do so if so - but only when switching on
+    if (on)
+        std::this_thread::sleep_for(this->get_closing_delay_left());
+
+    // the mentioned double check - return before we do actually anything
+    if (on and not this->execute_actuator_state_on_switch)
         return false;
 
-    this->delay_contactor_close = false;
-    return true;
-}
+    // check whether we actually need to toggle
+    if (on == this->get_actuator_state())
+        return true;
 
-std::chrono::seconds CbTarragonRelay::get_contactor_close_interval(void) {
-    return this->contactor_close_interval;
-}
+    // determine whether we are expecting a state change on feedback
+    this->set_expected_edge(on);
 
-void CbTarragonRelay::set_actuator_state(bool new_state_on) {
+    // actually toggle the relay
     this->actuator->set_value(this->actuator->offsets()[0],
-                              new_state_on ? gpiod::line::value::ACTIVE : gpiod::line::value::INACTIVE);
+                              on ? gpiod::line::value::ACTIVE : gpiod::line::value::INACTIVE);
+
+    // remember the timestamp when we switched on
+    if (on)
+        this->last_closed_ts = std::chrono::steady_clock::now();
+
+    // in case we have no feedback to verify our operation, or we don't expect a state change,
+    // or we don't want to wait, then just return success
+    if (!this->feedback or !this->expected_edge.has_value() or !wait_for_feedback)
+        return true;
+
+    // sleep until the edge was seen or a timeout occurred
+    this->cv_expected_edge.wait_for(lock, this->feedback_timeout,
+                                    [&] { return this->expected_edge_matched.has_value(); });
+
+    // take over the result (or false on timeout)
+    return this->expected_edge_matched.value_or(false);
 }
 
-bool CbTarragonRelay::get_actuator_state(void) {
+void CbTarragonRelay::set_expected_edge(bool on) {
+    // if we have a feedback, let's check the current state to determine, whether we can expect a state change
+    if (this->feedback and this->get_feedback_state() == this->get_actuator_state()) {
+        // remember what to expect next
+        this->expected_edge =
+            on ? gpiod::edge_event::event_type::RISING_EDGE : gpiod::edge_event::event_type::FALLING_EDGE;
+    } else {
+        // no state change expected
+        this->expected_edge.reset();
+    }
+
+    // reset any left over return value
+    this->expected_edge_matched.reset();
+}
+
+bool CbTarragonRelay::get_actuator_state() const {
     return this->actuator->get_value(this->actuator->offsets()[0]) == gpiod::line::value::ACTIVE;
 }
 
-CbContactorFeedbackType CbTarragonRelay::get_feedback_type(const std::string& feedback_type) {
-    CbContactorFeedbackType rv_feedback_type = CbContactorFeedbackType::NONE;
-
-    if (feedback_type == "no")
-        rv_feedback_type = CbContactorFeedbackType::NORMALLY_OPEN;
-    else if (feedback_type == "nc")
-        rv_feedback_type = CbContactorFeedbackType::NORMALLY_CLOSED;
-
-    return rv_feedback_type;
-}
-
-bool CbTarragonRelay::get_feedback_state(void) {
-    bool result;
-
-    // in case there is no feedback connected to relay, we just read the actuator state
-    if (this->feedback_type == CbContactorFeedbackType::NONE)
+bool CbTarragonRelay::get_feedback_state() const {
+    if (!this->feedback)
         return this->get_actuator_state();
 
-    result = (this->feedback->get_value(this->feedback->offsets()[0]) == gpiod::line::value::ACTIVE);
-
-    if (this->feedback_type == CbContactorFeedbackType::NORMALLY_CLOSED)
-        result = !result;
-
-    return result;
+    return this->feedback->get_value(this->feedback->offsets()[0]) == gpiod::line::value::ACTIVE;
 }
 
-bool CbTarragonRelay::wait_for_feedback(const std::chrono::nanoseconds& timeout) const {
-    return this->feedback->wait_edge_events(timeout);
+void CbTarragonRelay::set_expected_feedback_change(bool on) {
+    std::scoped_lock lock(this->expected_edge_mutex);
+
+    this->set_expected_edge(on);
 }
 
-gpiod::edge_event::event_type CbTarragonRelay::read_feedback_event(void) {
-    this->feedback->read_edge_events(this->feedback_event_buffer, 1);
+std::chrono::milliseconds CbTarragonRelay::get_closing_delay_left() const {
+    auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(
+        this->min_close_interval - (std::chrono::steady_clock::now() - this->last_closed_ts));
 
-    return this->feedback_event_buffer.get_event(0).type();
+    // if there is still time to wait, return the amount
+    if (remaining > 0ms)
+        return remaining;
+
+    // otherwise return zero
+    return 0ms;
 }
 
-bool CbTarragonRelay::verify_feedback_event(gpiod::edge_event::event_type event) {
-    if ((event == gpiod::edge_event::event_type::FALLING_EDGE) &&
-        (this->feedback_type == CbContactorFeedbackType::NORMALLY_CLOSED))
-        return 1;
-
-    if ((event == gpiod::edge_event::event_type::RISING_EDGE) &&
-        (this->feedback_type == CbContactorFeedbackType::NORMALLY_OPEN))
-        return 1;
-
-    return 0;
+std::ostream& operator<<(std::ostream& os, const CbTarragonRelay& r) {
+    os << r.relay_name << " (" << (r.get_actuator_state() ? "CLOSED" : "OPEN") << ", ";
+    if (r.feedback) {
+        os << (r.get_feedback_state() ? "CLOSED" : "OPEN");
+    } else {
+        os << "UNUSED";
+    }
+    os << ")";
+    return os;
 }

--- a/modules/CbTarragonDriver/tarragon/CbTarragonRelay.hpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonRelay.hpp
@@ -1,90 +1,82 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright chargebyte GmbH and Contributors to EVerest
 #pragma once
+#include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <memory>
+#include <mutex>
+#include <ostream>
+#include <optional>
 #include <string>
+#include <thread>
+#include <sigslot/signal.hpp>
 #include <gpiod.hpp>
 
-/// @brief Class representing the 3 possible contactor feedback types.
-enum class CbContactorFeedbackType {
-    NONE,
-    NORMALLY_OPEN,
-    NORMALLY_CLOSED
-};
+using namespace std::chrono_literals;
 
 class CbTarragonRelay {
 
 public:
-    /// @brief Default constructor
-    CbTarragonRelay(void);
-
     /// @brief Constructor
-    /// @param contactor_relay Name of the relay and its feedback as labeled on hardware.
+    /// @param relay_name Name of the relay and its feedback sense as labeled on hardware.
     /// @param actuator_gpio_line_name The name of the GPIO line which switches the relay on/off.
-    /// @param feedback_type Defines the logic behind the feedback (no = normally open, nc = normally close, none = no
-    /// feedback).
-    /// @param feedback_gpio_line_name The name of the GPIO line to which the feedback/sense signal of relay 1 is
+    /// @param feedback_gpio_line_name The name of the GPIO line to which the feedback (aka sense) circuit is
     /// connected to.
     /// @param feedback_gpio_debounce_us The debounce period which should be configured for the feedback GPIO (in [us]).
     /// Pass a value of zero to skip any configuration.
     CbTarragonRelay(const std::string& relay_name, const std::string& actuator_gpio_line_name,
-                    const std::string& feedback_type, const std::string& feedback_gpio_line_name,
-                    const unsigned int feedback_gpio_debounce_us);
+                    const std::string& feedback_gpio_line_name, const unsigned int feedback_gpio_debounce_us);
 
-    /// @brief Set the timestamp of the last contactor state change from closed to open
-    void set_last_contactor_open_ts(std::chrono::time_point<std::chrono::steady_clock> timestamp);
+    /// @brief Destructor.
+    ~CbTarragonRelay();
 
-    /// @brief Set the flag `delay_contactor_close`.
-    void set_delay_contactor_close(bool value);
+    /// @brief Tells whether the feedback signal monitoring should be used and actually starts it if so.
+    ///        This function must be called before any other member functions are used.
+    /// @param use_feedback True - use the feedback signal; false - ignore it.
+    /// @param active_low Tells whether the feedback line should use inverted logic.
+    void start(bool use_feedback, bool active_low);
 
-    /// @brief Check if the contactor could be closed immediately i.e. switching the relay on, or
-    ///        if this operation should be delayed to prevent internal relay wear.
-    /// @return `true` if it can be closed, `false` if delayed
-    bool can_close_contactor(void);
-
-    // @brief Return the value of contactor_close_interval.
-    std::chrono::seconds get_contactor_close_interval(void);
-
-    /// @brief Switch the relay on/off.
-    /// @param new_state_on The target state (0 = off, 1 = on).
-    void set_actuator_state(bool new_state_on);
+    /// @brief Switch the relay on/off. This function ensures that the minimum close interval between
+    ///        consecutive closings is respected (ie. waits until the GPIO can be actually switched).
+    ///        Usually, the function waits for the feedback confirming the switch, but this can be prevented
+    ///        since in some setups, we might not see the feedback immediately.
+    /// @param on The target state (true = on, false = off)
+    /// @param wait_for_feedback Tell whether to wait and evaluate the feedback before returning.
+    /// @return Returns true if the new state was reached successfully (based on sense signal evaluation if configured),
+    /// false otherwise.
+    bool set_actuator_state(bool on, bool wait_for_feedback);
 
     /// @brief Read the actual GPIO state of the actuator.
-    bool get_actuator_state(void);
+    bool get_actuator_state() const;
 
-    /// @brief Function to map the string feedback type to CbContactorFeedbackType.
-    /// @param feedback_type String representing the feedback type (no = normally open, nc = normally close, none = no
-    /// feedback).
-    /// @return Return NONE as default, NORMALLY_OPEN, NORMALLY_CLOSE.
-    CbContactorFeedbackType get_feedback_type(const std::string& feedback_type);
+    /// @brief Read the actual GPIO state of the feedback. If `start` was called with `use_feedback` set to `false`,
+    ///        then this function just returns the current actuator state.
+    bool get_feedback_state() const;
 
-    /// @brief Read the actual state of the GPIO of the contactor feedback.
-    bool get_feedback_state(void);
+    /// @brief Tell the feedback monitor about an expected feedback change which is not initiated by
+    ///        a call to `set_actuator_state`, e.g. because of a special serial wiring of multiple contactors.
+    void set_expected_feedback_change(bool on);
 
-    /// @brief Wait for duration of 'timeout' for a new event to happen on the GPIO.
-    /// @param timeout The duration to wait for an event to happen.
-    /// @return Return '1' in case there are new events and '0' if otherwise
-    bool wait_for_feedback(const std::chrono::nanoseconds& timeout) const;
+    /// @brief Return the time to wait until the relay can be closed again.
+    std::chrono::milliseconds get_closing_delay_left() const;
 
-    /// @brief Read events in a buffer. This is a blocking function and therefore it should
-    ///        be used only if there are new events to read i.e., in combination with the function wait_for_feedback.
-    /// @return Return an edge event (FALLING_EDGE or RISING_EDGE).
-    gpiod::edge_event::event_type read_feedback_event(void);
+    /// @brief Signal used to inform about unexpected state changes on the feedback GPIO.
+    sigslot::signal<const std::string&, bool> on_unexpected_change;
 
-    /// @brief Map edge events (FALLING_EDGE, RISING_EDGE)to contactor states.
-    /// @return Return '0' if opened, '1' if closed.
-    bool verify_feedback_event(gpiod::edge_event::event_type event);
+    /// @brief Feeds a string representation of the given CbTarragonRelay instance into an output stream.
+    /// @return A reference to the output stream operated on.
+    friend std::ostream& operator<<(std::ostream& os, const CbTarragonRelay& r);
 
 private:
     /// @brief Name of the relay and its feedback as labeled on hardware.
     std::string relay_name;
 
-    /// @brief Define the logic behind the feedback (no = normally open, nc = normally close, none = no feedback).
-    CbContactorFeedbackType feedback_type;
+    /// @brief Name of the GPIO line to use for feedback/sense detection.
+    std::string feedback_gpio_line_name;
 
-    /// @brief Buffer to store the new edge event
-    gpiod::edge_event_buffer feedback_event_buffer;
+    /// @brief The debounce period which should be configured for the feedback GPIO (in [us]).
+    const unsigned int feedback_gpio_debounce_us;
 
     /// @brief The GPIO handle of the used actuator (RELAY_1_ENABLE or RELAY_2_ENABLE).
     std::unique_ptr<gpiod::line_request> actuator;
@@ -92,17 +84,46 @@ private:
     /// @brief The GPIO handle of the used feedback (RELAY_1_SENSE or RELAY_2_SENSE).
     std::unique_ptr<gpiod::line_request> feedback;
 
+    /// @brief This helper allows to remember whether a `set_actuator_state(false)` was
+    ///        seen while we wait for the `min_close_interval`.
+    std::atomic_bool execute_actuator_state_on_switch {false};
+
+    /// @brief Remember the next expected feedback edge event type in case of an actuator change initiated by ourself.
+    std::optional<gpiod::edge_event::event_type> expected_edge;
+
+    /// @brief Set the next expected feedback edge event type
+    ///        Must be called with the mutex `expected_edge_mutex` hold.
+    void set_expected_edge(bool on);
+
+    /// @brief This is basically the return value of `set_actuator_state`.
+    std::optional<bool> expected_edge_matched;
+
+    /// @brief Protects `expected_edge` and `expected_edge_matched.
+    std::mutex expected_edge_mutex;
+
+    /// @brief Used to signal `expected_edge_matched` back to the `set_actuator_state` method.
+    std::condition_variable cv_expected_edge;
+
     /// @brief The timestamp which records the moment when the contactor's state transitioned
-    ///        from closed to open.
-    std::chrono::time_point<std::chrono::steady_clock> last_contactor_open_ts;
+    ///        from OPEN to CLOSED.
+    std::chrono::time_point<std::chrono::steady_clock> last_closed_ts;
 
-    /// @brief The time in seconds which represents a minimum duration between contactor
-    ///        closings to prevent internal relay wear. The worst considered contactor type
+    /// @brief The time in seconds which represents a minimum duration between relay
+    ///        closings to prevent internal relay wear out. The worst considered relay type
     //         can withstand a maximum of 6 cycles (open and close actions) per
-    ///        minute i.e., 10 seconds between 2 contactor closings.
-    std::chrono::seconds contactor_close_interval;
+    ///        minute i.e., 10 seconds between 2 relay closings.
+    std::chrono::milliseconds min_close_interval {10s};
 
-    /// @brief A flag that is set to `true` when it is needed to delay closing of the contactor
-    ///        to prevent the internal relay wear.
-    bool delay_contactor_close;
+    /// @brief The time in milliseconds until the feedback GPIO should have reported
+    ///        an edge event when the relay was switched.
+    std::chrono::milliseconds feedback_timeout {250ms};
+
+    /// @brief Helper to signal thread termination wish
+    std::atomic_bool termination_requested {false};
+
+    /// @brief Thread handle of feedback GPIO monitoring thread.
+    std::thread feedback_monitor;
+
+    /// @brief Feedback GPIO monitoring thread worker function.
+    void feedback_monitor_worker();
 };

--- a/types/cb_board_support.yaml
+++ b/types/cb_board_support.yaml
@@ -19,3 +19,25 @@ types:
       - E
       - F
       - PilotFault
+  ContactorState:
+    description: Models the state of a contactor
+    type: string
+    enum:
+      - Unknown
+      - Open
+      - Closed
+  ContactorFeedbackType:
+    description: >-
+       Models the feedback type of the auxiliary contact of the contactor:
+       none - no feedback signal is used
+       nc - the feedback signal is wired to a normally-closed contact
+       no - the feedback signal is wired to a normally-open contact
+       Notes:
+       - we have to use quotes here to force string evaluation,
+         otherwise "no" would be converted to "False".
+       - we use lower-case strings to match the manifest configuration values
+    type: string
+    enum:
+      - "none"
+      - "nc"
+      - "no"


### PR DESCRIPTION
This PR refactors the contactor controlling and adds support for upcoming 'mutual' wiring setups.

The design goals were:
 - make the internal API synchronous
 - simplify the whole code base by moving responsibilities to the respective classes
 - use C++ inheritance where applicable to get rid of condition paths
