### PR TITLE
CbTarragonDriver: fix RCM corner case while power on throttling is ac…

### DIFF
--- a/modules/CbTarragonDriver/tarragon/CbTarragonContactor.hpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonContactor.hpp
@@ -29,8 +29,8 @@ public:
     /// @brief Switch the contactor on/off.
     /// @param on The target state (true = on, false = off)
     /// @param wait_for_feedback Tell whether to wait and evaluate the feedback before returning.
-    /// @return Returns true if the new state was reached successfully (based on feedback if configured),
-    /// false otherwise.
+    /// @return Returns false if there is probably a contactor error (based on feedback if configured),
+    ///         true otherwise.
     bool switch_state(bool on, bool wait_for_feedback);
 
     /// @brief Read the actual state (based on actuator line).

--- a/modules/CbTarragonDriver/tarragon/CbTarragonRelay.cpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonRelay.cpp
@@ -132,8 +132,9 @@ bool CbTarragonRelay::set_actuator_state(bool on, bool wait_for_feedback) {
         std::this_thread::sleep_for(this->get_closing_delay_left());
 
     // the mentioned double check - return before we do actually anything
+    // but report it as success - otherwise a contactor error is triggered which is not true here
     if (on and not this->execute_actuator_state_on_switch)
-        return false;
+        return true;
 
     // check whether we actually need to toggle
     if (on == this->get_actuator_state())

--- a/modules/CbTarragonDriver/tarragon/CbTarragonRelay.hpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonRelay.hpp
@@ -43,8 +43,8 @@ public:
     ///        since in some setups, we might not see the feedback immediately.
     /// @param on The target state (true = on, false = off)
     /// @param wait_for_feedback Tell whether to wait and evaluate the feedback before returning.
-    /// @return Returns true if the new state was reached successfully (based on sense signal evaluation if configured),
-    /// false otherwise.
+    /// @return Returns false if the new state could not reached successfully (based on sense signal evaluation
+    ///         if configured and thus it is probably a contactor error), true otherwise.
     bool set_actuator_state(bool on, bool wait_for_feedback);
 
     /// @brief Read the actual GPIO state of the actuator.


### PR DESCRIPTION
…tive

In case the RCM reports an error while the power on throttling is active, e.g. we are waiting to close the contactor, then we reported a contactor error. But this is not the case here, we just skipped the real contactor closing, so we have to report success in this case to prevent the upstream error generation.