### PR TITLE
InfypowerDCSupply: introduce config option 'override_cutoff_voltage'

### DIFF
--- a/modules/InfypowerDCSupply/InfypowerDCSupply.hpp
+++ b/modules/InfypowerDCSupply/InfypowerDCSupply.hpp
@@ -30,6 +30,7 @@ struct Conf {
     std::string dc_module_type;
     double override_max_current;
     double override_max_power;
+    double override_cutoff_voltage;
 };
 
 class InfypowerDCSupply : public Everest::ModuleBase {

--- a/modules/InfypowerDCSupply/main/power_supply_DCImpl.cpp
+++ b/modules/InfypowerDCSupply/main/power_supply_DCImpl.cpp
@@ -130,8 +130,12 @@ void power_supply_DCImpl::handle_setImportVoltageCurrent(double& voltage, double
                << current << " A)";
     try {
         // since we do not have any other voltage from EVerest, we assume that
-        // the voltage is carefully chosen and represents the cut-off voltage
-        this->mod->controller.set_import_cutoff_voltage(voltage);
+        // the voltage is carefully chosen and represents the cut-off voltage;
+        // the user however might have configured an override in the configuration
+        if (this->mod->config.override_cutoff_voltage >= 0.0)
+            this->mod->controller.set_import_cutoff_voltage(this->mod->config.override_cutoff_voltage);
+        else
+            this->mod->controller.set_import_cutoff_voltage(voltage);
 
         // the voltage here is probably not important and ignored by the PM
         // but we re-use the function for setting the current

--- a/modules/InfypowerDCSupply/manifest.yaml
+++ b/modules/InfypowerDCSupply/manifest.yaml
@@ -54,6 +54,19 @@ config:
       then the value reported by the power module itself is used.
     type: number
     default: -1
+  override_cutoff_voltage:
+    description: >-
+      When using BPT and the request is to discharge the EV, then the power module
+      needs a cut-off voltage to know when charging should be stopped.
+      With ISO15118-20, this parameter is communicated by the EV, but in combination
+      with the hack for DIN70121 or ISO15118-2 (see documentation of EvseManager etc),
+      it is sometimes desired to ignore the value given by the EvseManager and use
+      a fixed one instead. This option allows to specify such a fixed value in volts.
+      Any value equal to or greater than zero is used as-is - without any further checks.
+      To disable this override, use any negative number, then the voltage given by
+      EvseManager is used. This is also the default behavior.
+    type: number
+    default: -1
 provides:
   main:
     interface: power_supply_DC


### PR DESCRIPTION
This allows more control over the discharging when used in combination with DIN70121 or ISO15118-2 hack.