### PR TITLE
CbTarragonDriver: fix 3ph-1ph switching feature for serial wiring setups

### DIFF
--- a/modules/CbTarragonDriver/tarragon/CbTarragonContactor.cpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonContactor.cpp
@@ -55,6 +55,10 @@ void CbTarragonContactor::set_expected_feedback_change(bool on) {
     this->relay->set_expected_feedback_change(on);
 }
 
+bool CbTarragonContactor::wait_for_feedback() {
+    return this->relay->wait_for_feedback();
+}
+
 std::chrono::milliseconds CbTarragonContactor::get_closing_delay_left() const {
     return this->relay->get_closing_delay_left();
 }

--- a/modules/CbTarragonDriver/tarragon/CbTarragonContactor.hpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonContactor.hpp
@@ -47,6 +47,11 @@ public:
     ///        ourself, e.g. because of a special serial wiring of multiple contactors.
     void set_expected_feedback_change(bool on);
 
+    /// @brief Sleeps until the next change event on the feedback signal occurs.
+    /// @return Returns false if the new state could not reached successfully (based on sense signal evaluation
+    ///         if configured and thus it is probably a contactor error), true otherwise.
+    bool wait_for_feedback();
+
     /// @brief Return the time to wait until the contactor can be closed again.
     std::chrono::milliseconds get_closing_delay_left() const;
 

--- a/modules/CbTarragonDriver/tarragon/CbTarragonContactorControlSerial.cpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonContactorControlSerial.cpp
@@ -70,9 +70,7 @@ bool CbTarragonContactorControlSerial::switch_state(bool on) {
 
         // now the secondary contactor should have also switched
         if (this->phase_count == 3) {
-            auto secondary_contactor_state {this->secondary.get_feedback_state()};
-
-            rv_secondary = secondary_contactor_state == types::cb_board_support::ContactorState::Closed;
+            rv_secondary = this->secondary.wait_for_feedback();
 
             // switch_contactor would have raised an error in case we had waited
             // but since we didn't we have to take care here

--- a/modules/CbTarragonDriver/tarragon/CbTarragonContactorControlSerial.cpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonContactorControlSerial.cpp
@@ -77,10 +77,7 @@ bool CbTarragonContactorControlSerial::switch_state(bool on) {
             // switch_contactor would have raised an error in case we had waited
             // but since we didn't we have to take care here
             if (!rv_secondary) {
-                auto actual_contactor_state {on ? types::cb_board_support::ContactorState::Open
-                                                : types::cb_board_support::ContactorState::Closed};
-
-                this->on_error(this->secondary.get_name(), on, actual_contactor_state);
+                this->on_error(this->secondary.get_name(), on, types::cb_board_support::ContactorState::Open);
 
                 // switch back both to be on safe side
                 this->switch_contactor(this->primary, false, false);

--- a/modules/CbTarragonDriver/tarragon/CbTarragonContactorControlSerial.cpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonContactorControlSerial.cpp
@@ -62,10 +62,30 @@ bool CbTarragonContactorControlSerial::switch_state(bool on) {
         }
 
         rv_primary = this->switch_contactor(this->primary, on);
+        if (!rv_primary && this->phase_count == 3) {
+            // switch back the secondary to be safe (but it should not be energized at all)
+            this->switch_contactor(this->secondary, false, false);
+            return false;
+        }
 
         // now the secondary contactor should have also switched
         if (this->phase_count == 3) {
-            rv_secondary = this->secondary.get_feedback_state() == types::cb_board_support::ContactorState::Closed;
+            auto secondary_contactor_state {this->secondary.get_feedback_state()};
+
+            rv_secondary = secondary_contactor_state == types::cb_board_support::ContactorState::Closed;
+
+            // switch_contactor would have raised an error in case we had waited
+            // but since we didn't we have to take care here
+            if (!rv_secondary) {
+                auto actual_contactor_state {on ? types::cb_board_support::ContactorState::Open
+                                                : types::cb_board_support::ContactorState::Closed};
+
+                this->on_error(this->secondary.get_name(), on, actual_contactor_state);
+
+                // switch back both to be on safe side
+                this->switch_contactor(this->primary, false, false);
+                this->switch_contactor(this->secondary, false, false);
+            }
         } else {
             // not switched, so must be neutral for following and-condition in return
             rv_secondary = true;

--- a/modules/CbTarragonDriver/tarragon/CbTarragonRelay.hpp
+++ b/modules/CbTarragonDriver/tarragon/CbTarragonRelay.hpp
@@ -58,6 +58,11 @@ public:
     ///        a call to `set_actuator_state`, e.g. because of a special serial wiring of multiple contactors.
     void set_expected_feedback_change(bool on);
 
+    /// @brief Sleeps until the next change event on the feedback signal occurs.
+    /// @return Returns false if the new state could not reached successfully (based on sense signal evaluation
+    ///         if configured and thus it is probably a contactor error), true otherwise.
+    bool wait_for_feedback();
+
     /// @brief Return the time to wait until the relay can be closed again.
     std::chrono::milliseconds get_closing_delay_left() const;
 
@@ -94,6 +99,12 @@ private:
     /// @brief Set the next expected feedback edge event type
     ///        Must be called with the mutex `expected_edge_mutex` hold.
     void set_expected_edge(bool on);
+
+    /// @brief Sleeps until the next change event on the feedback signal occurs.
+    /// @param lock Reference to the lock to re-use.
+    /// @return Returns false if the new state could not reached successfully (based on sense signal evaluation
+    ///         if configured and thus it is probably a contactor error), true otherwise.
+    bool wait_for_feedback_lock(std::unique_lock<std::mutex>& lock);
 
     /// @brief This is basically the return value of `set_actuator_state`.
     std::optional<bool> expected_edge_matched;


### PR DESCRIPTION
This PR fixes the 3ph-1ph switching feature for `serial` wiring setups. The original problem was, that the switching time of the secondary relay was not considered. This prevented detecting that the secondary contactor actually switched.

Furthermore, this wasn't even reported to the EvseManager.
