### PR TITLE
Add/improve error logging and reporting for ChargeSOM and Charge Control Y

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,12 @@
 *build
-*build-cross
+*build-*
 *.cache
 *.cproject
 *.project
 *.settings
 *.vscode
 workspace.yaml
+*.orig
+*.patch
+*.diff
+*.rej

--- a/errors/cb_chargesom_temperatures.yaml
+++ b/errors/cb_chargesom_temperatures.yaml
@@ -1,0 +1,7 @@
+description: >-
+  Errors used by Charge SOM temperature interface
+errors:
+  - name: SelftestFailed
+    description: Temperature channel failed the internal selftest.
+  - name: ChargingAbort
+    description: Temperature channel caused a charging session abort.

--- a/interfaces/cb_chargesom_temperatures.yaml
+++ b/interfaces/cb_chargesom_temperatures.yaml
@@ -7,4 +7,4 @@ vars:
       type: object
       $ref: /temperature#/Temperature
 errors:
-  - reference: /errors/generic
+  - reference: /errors/cb_chargesom_temperatures

--- a/modules/CbChargeSOMDriver/chargesom/CbChargeSOM.cpp
+++ b/modules/CbChargeSOMDriver/chargesom/CbChargeSOM.cpp
@@ -227,8 +227,8 @@ CbChargeSOM::CbChargeSOM() {
             reason = cb_proto_errmsg_get_reason(&tmpctx);
             additional_data1 = cb_proto_errmsg_get_additional_data_1(&tmpctx);
             additional_data2 = cb_proto_errmsg_get_additional_data_2(&tmpctx);
-            std::string module_str{cb_proto_errmsg_module_to_str(module)};
-            std::string reason_str{cb_proto_errmsg_reason_to_str(module, reason)};
+            std::string module_str {cb_proto_errmsg_module_to_str(module)};
+            std::string reason_str {cb_proto_errmsg_reason_to_str(module, reason)};
 
             this->on_errmsg(is_active, static_cast<unsigned int>(module), module_str, reason, reason_str,
                             additional_data1, additional_data2);
@@ -319,14 +319,16 @@ CbChargeSOM::CbChargeSOM() {
                 // but it also does not hurt
                 break;
 
-            case cb_uart_com::COM_ERROR_MESSAGE: {
+            case cb_uart_com::COM_ERROR_MESSAGE:
                 this->ctx.error_message = payload;
                 // it is not necessary to wake-up the "normal" waiters
                 notify = false;
-                std::scoped_lock notify_lock(this->errmsg_mutex);
-                this->errmsg_queue.push(payload);
+                {
+                    std::scoped_lock errmsg_lock(this->errmsg_mutex);
+                    this->errmsg_queue.push(payload);
+                }
                 this->errmsg_cv.notify_one();
-            } break;
+                break;
 
             case cb_uart_com::COM_FW_VERSION:
                 this->ctx.fw_version = payload;

--- a/modules/CbChargeSOMDriver/chargesom/CbChargeSOM.cpp
+++ b/modules/CbChargeSOMDriver/chargesom/CbChargeSOM.cpp
@@ -195,6 +195,48 @@ CbChargeSOM::CbChargeSOM() {
         EVLOG_debug << "Notify Thread terminated";
     });
 
+    // we need a thread to handle all the error message notifications asynchronously
+    // to the frame receiving to avoid stalling and to not miss a single one
+    this->errmsg_thread = std::thread([&]() {
+        EVLOG_debug << "Error Message Thread started";
+
+        while (!this->termination_requested) {
+            // temporary helper variables for our access functions
+            struct safety_controller tmpctx;
+            bool is_active;
+            enum errmsg_module module;
+            unsigned int reason;
+            unsigned int additional_data1;
+            unsigned int additional_data2;
+
+            // wait for events
+            std::unique_lock<std::mutex> lock(this->errmsg_mutex);
+            this->errmsg_cv.wait(lock, [&]() {
+                return (!this->errmsg_queue.empty() && this->evse_enabled) || this->termination_requested;
+            });
+
+            if (this->termination_requested)
+                break;
+
+            // remove from queue
+            tmpctx.error_message = this->errmsg_queue.front();
+            this->errmsg_queue.pop();
+
+            is_active = cb_proto_errmsg_is_active(&tmpctx);
+            module = cb_proto_errmsg_get_module(&tmpctx);
+            reason = cb_proto_errmsg_get_reason(&tmpctx);
+            additional_data1 = cb_proto_errmsg_get_additional_data_1(&tmpctx);
+            additional_data2 = cb_proto_errmsg_get_additional_data_2(&tmpctx);
+            std::string module_str{cb_proto_errmsg_module_to_str(module)};
+            std::string reason_str{cb_proto_errmsg_reason_to_str(module, reason)};
+
+            this->on_errmsg(is_active, static_cast<unsigned int>(module), module_str, reason, reason_str,
+                            additional_data1, additional_data2);
+        }
+
+        EVLOG_debug << "Error Message Thread terminated";
+    });
+
     // launch processing of received frames
     this->rx_thread = std::thread([&]() {
         // used to detect changes
@@ -276,6 +318,15 @@ CbChargeSOM::CbChargeSOM() {
                 // temperature interface polls in regular intervals by itself
                 // but it also does not hurt
                 break;
+
+            case cb_uart_com::COM_ERROR_MESSAGE: {
+                this->ctx.error_message = payload;
+                // it is not necessary to wake-up the "normal" waiters
+                notify = false;
+                std::scoped_lock notify_lock(this->errmsg_mutex);
+                this->errmsg_queue.push(payload);
+                this->errmsg_cv.notify_one();
+            } break;
 
             case cb_uart_com::COM_FW_VERSION:
                 this->ctx.fw_version = payload;

--- a/modules/CbChargeSOMDriver/chargesom/CbChargeSOM.hpp
+++ b/modules/CbChargeSOMDriver/chargesom/CbChargeSOM.hpp
@@ -101,6 +101,12 @@ public:
     ///        and third parameter is actual state.
     sigslot::signal<const std::string&, bool, types::cb_board_support::ContactorState> on_contactor_error;
 
+    /// @brief Signal used to inform about received error message
+    ///        The parameter is filled with the data from the latest error message string.
+    sigslot::signal<bool, unsigned int, const std::string&, unsigned int, const std::string&, unsigned int,
+                    unsigned int>
+        on_errmsg;
+
     /// @brief Return whether the safety controller detected an emergency state.
     bool is_emergency();
 
@@ -207,6 +213,18 @@ private:
 
     /// @brief Queue used to serialize changes of Charge State frame for notifying
     std::queue<uint64_t> charge_state_changes;
+
+    /// @brief Thread for pushing received error messages to higher layers.
+    std::thread errmsg_thread;
+
+    /// @brief Mutex to protect access to the `error_messages` queue.
+    std::mutex errmsg_mutex;
+
+    /// @brief Condition variables used to wait for updates on `error_messages`
+    std::condition_variable errmsg_cv;
+
+    /// @brief Queue used to serialize Error Message frames for notifying
+    std::queue<uint64_t> errmsg_queue;
 
     /// @brief Mutex to ensure that only one inquiry request is in-flight at the same time
     std::mutex inquiry_mutex;

--- a/modules/CbChargeSOMDriver/chargesom/CbChargeSOM.hpp
+++ b/modules/CbChargeSOMDriver/chargesom/CbChargeSOM.hpp
@@ -101,8 +101,8 @@ public:
     ///        and third parameter is actual state.
     sigslot::signal<const std::string&, bool, types::cb_board_support::ContactorState> on_contactor_error;
 
-    /// @brief Signal used to inform about received error message
-    ///        The parameter is filled with the data from the latest error message string.
+    /// @brief Signal emitted whenever an error message is received.
+    ///        The parameters are filled with the data from the latest error message.
     sigslot::signal<bool, unsigned int, const std::string&, unsigned int, const std::string&, unsigned int,
                     unsigned int>
         on_errmsg;

--- a/modules/CbChargeSOMDriver/evse_board_support/evse_board_supportImpl.cpp
+++ b/modules/CbChargeSOMDriver/evse_board_support/evse_board_supportImpl.cpp
@@ -257,9 +257,8 @@ void evse_board_supportImpl::init() {
                                                 unsigned int additional_data1, unsigned int additional_data2) {
         if (is_active) {
             std::ostringstream errmsg;
-            errmsg << reason_str << " (" << std::showbase << std::setw(4) << std::setfill('0') << std::hex << reason
-                   << "), " << std::showbase << std::setw(4) << std::setfill('0') << std::hex << additional_data1
-                   << ", " << std::showbase << std::setw(4) << std::setfill('0') << std::hex << additional_data2;
+            errmsg << std::showbase << std::setw(4) << std::setfill('0') << std::hex;
+            errmsg << reason_str << " (" << reason << "), " << additional_data1 << ", " << additional_data2;
 
             EVLOG_warning << "Safety Controller reported error: " << module_str << "(" << std::showbase << std::setw(4)
                           << std::setfill('0') << std::hex << module << "), " << errmsg.str();

--- a/modules/CbChargeSOMDriver/evse_board_support/evse_board_supportImpl.cpp
+++ b/modules/CbChargeSOMDriver/evse_board_support/evse_board_supportImpl.cpp
@@ -251,6 +251,35 @@ void evse_board_supportImpl::init() {
             ;
         }
     });
+
+    this->mod->controller.on_errmsg.connect([&](bool is_active, unsigned int module, const std::string& module_str,
+                                                unsigned int reason, const std::string& reason_str,
+                                                unsigned int additional_data1, unsigned int additional_data2) {
+        if (is_active) {
+            std::ostringstream errmsg;
+            errmsg << reason_str << " (" << std::showbase << std::setw(4) << std::setfill('0') << std::hex << reason
+                   << "), " << std::showbase << std::setw(4) << std::setfill('0') << std::hex << additional_data1
+                   << ", " << std::showbase << std::setw(4) << std::setfill('0') << std::hex << additional_data2;
+
+            EVLOG_warning << "Safety Controller reported error: " << module_str << "(" << std::showbase << std::setw(4)
+                          << std::setfill('0') << std::hex << module << "), " << errmsg.str();
+
+            auto e = this->error_factory->create_error("evse_board_support/VendorWarning", module_str, errmsg.str(),
+                                                       Everest::error::Severity::High);
+
+            this->raise_error(e);
+
+        } else {
+            std::ostringstream errmsg;
+            errmsg << reason_str << " (" << std::showbase << std::setw(4) << std::setfill('0') << std::hex << reason
+                   << ")";
+
+            EVLOG_info << "Safety Controller cleared error: " << module_str << "(" << std::showbase << std::setw(4)
+                       << std::setfill('0') << std::hex << module << "), " << errmsg.str();
+
+            this->clear_error("evse_board_support/VendorWarning", module_str);
+        }
+    });
 }
 
 void evse_board_supportImpl::ready() {

--- a/modules/CbChargeSOMDriver/temperatures/cb_chargesom_temperaturesImpl.hpp
+++ b/modules/CbChargeSOMDriver/temperatures/cb_chargesom_temperaturesImpl.hpp
@@ -39,6 +39,8 @@ public:
     // ev@8ea32d28-373f-4c90-ae5e-b4fcc74e2a61:v1
 
 protected:
+    // no commands defined for this interface
+
     // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1
     // insert your protected definitions here
     // ev@d2d1847a-7b88-41dd-ad07-92785f06f5c4:v1

--- a/modules/CbParsleyDriver/evse_board_support/evse_board_supportImpl.cpp
+++ b/modules/CbParsleyDriver/evse_board_support/evse_board_supportImpl.cpp
@@ -88,8 +88,7 @@ void evse_board_supportImpl::init() {
 
         // in case safety controller was in emergency state and EV is gone,
         // we have to reset safety controller with a disable -> enable toggle
-        if (current_cp_state == types::cb_board_support::CPState::A and
-            this->mod->controller.is_emergency()) {
+        if (current_cp_state == types::cb_board_support::CPState::A and this->mod->controller.is_emergency()) {
             EVLOG_info << "recovering after safe state";
 
             // disable resets the controller
@@ -173,9 +172,8 @@ void evse_board_supportImpl::init() {
                                                 unsigned int additional_data1, unsigned int additional_data2) {
         if (is_active) {
             std::ostringstream errmsg;
-            errmsg << reason_str << " (" << std::showbase << std::setw(4) << std::setfill('0') << std::hex << reason
-                   << "), " << std::showbase << std::setw(4) << std::setfill('0') << std::hex << additional_data1
-                   << ", " << std::showbase << std::setw(4) << std::setfill('0') << std::hex << additional_data2;
+            errmsg << std::showbase << std::setw(4) << std::setfill('0') << std::hex;
+            errmsg << reason_str << " (" << reason << "), " << additional_data1 << ", " << additional_data2;
 
             EVLOG_warning << "Safety Controller reported error: " << module_str << "(" << std::showbase << std::setw(4)
                           << std::setfill('0') << std::hex << module << "), " << errmsg.str();

--- a/modules/CbParsleyDriver/evse_board_support/evse_board_supportImpl.cpp
+++ b/modules/CbParsleyDriver/evse_board_support/evse_board_supportImpl.cpp
@@ -167,6 +167,35 @@ void evse_board_supportImpl::init() {
             ;
         }
     });
+
+    this->mod->controller.on_errmsg.connect([&](bool is_active, unsigned int module, const std::string& module_str,
+                                                unsigned int reason, const std::string& reason_str,
+                                                unsigned int additional_data1, unsigned int additional_data2) {
+        if (is_active) {
+            std::ostringstream errmsg;
+            errmsg << reason_str << " (" << std::showbase << std::setw(4) << std::setfill('0') << std::hex << reason
+                   << "), " << std::showbase << std::setw(4) << std::setfill('0') << std::hex << additional_data1
+                   << ", " << std::showbase << std::setw(4) << std::setfill('0') << std::hex << additional_data2;
+
+            EVLOG_warning << "Safety Controller reported error: " << module_str << "(" << std::showbase << std::setw(4)
+                          << std::setfill('0') << std::hex << module << "), " << errmsg.str();
+
+            auto e = this->error_factory->create_error("evse_board_support/VendorWarning", module_str, errmsg.str(),
+                                                       Everest::error::Severity::High);
+
+            this->raise_error(e);
+
+        } else {
+            std::ostringstream errmsg;
+            errmsg << reason_str << " (" << std::showbase << std::setw(4) << std::setfill('0') << std::hex << reason
+                   << ")";
+
+            EVLOG_info << "Safety Controller cleared error: " << module_str << "(" << std::showbase << std::setw(4)
+                       << std::setfill('0') << std::hex << module << "), " << errmsg.str();
+
+            this->clear_error("evse_board_support/VendorWarning", module_str);
+        }
+    });
 }
 
 void evse_board_supportImpl::ready() {

--- a/modules/CbParsleyDriver/parsley/CbParsley.cpp
+++ b/modules/CbParsleyDriver/parsley/CbParsley.cpp
@@ -225,8 +225,8 @@ CbParsley::CbParsley() {
             reason = cb_proto_errmsg_get_reason(&tmpctx);
             additional_data1 = cb_proto_errmsg_get_additional_data_1(&tmpctx);
             additional_data2 = cb_proto_errmsg_get_additional_data_2(&tmpctx);
-            std::string module_str{cb_proto_errmsg_module_to_str(module)};
-            std::string reason_str{cb_proto_errmsg_reason_to_str(module, reason)};
+            std::string module_str {cb_proto_errmsg_module_to_str(module)};
+            std::string reason_str {cb_proto_errmsg_reason_to_str(module, reason)};
 
             this->on_errmsg(is_active, static_cast<unsigned int>(module), module_str, reason, reason_str,
                             additional_data1, additional_data2);
@@ -317,14 +317,16 @@ CbParsley::CbParsley() {
                 // but it also does not hurt
                 break;
 
-            case cb_uart_com::COM_ERROR_MESSAGE: {
+            case cb_uart_com::COM_ERROR_MESSAGE:
                 this->ctx.error_message = payload;
                 // it is not necessary to wake-up the "normal" waiters
                 notify = false;
-                std::scoped_lock notify_lock(this->errmsg_mutex);
-                this->errmsg_queue.push(payload);
+                {
+                    std::scoped_lock errmsg_lock(this->errmsg_mutex);
+                    this->errmsg_queue.push(payload);
+                }
                 this->errmsg_cv.notify_one();
-            } break;
+                break;
 
             case cb_uart_com::COM_FW_VERSION:
                 this->ctx.fw_version = payload;

--- a/modules/CbParsleyDriver/parsley/CbParsley.cpp
+++ b/modules/CbParsleyDriver/parsley/CbParsley.cpp
@@ -193,6 +193,48 @@ CbParsley::CbParsley() {
         EVLOG_debug << "Notify Thread terminated";
     });
 
+    // we need a thread to handle all the error message notifications asynchronously
+    // to the frame receiving to avoid stalling and to not miss a single one
+    this->errmsg_thread = std::thread([&]() {
+        EVLOG_debug << "Error Message Thread started";
+
+        while (!this->termination_requested) {
+            // temporary helper variables for our access functions
+            struct safety_controller tmpctx;
+            bool is_active;
+            enum errmsg_module module;
+            unsigned int reason;
+            unsigned int additional_data1;
+            unsigned int additional_data2;
+
+            // wait for events
+            std::unique_lock<std::mutex> lock(this->errmsg_mutex);
+            this->errmsg_cv.wait(lock, [&]() {
+                return (!this->errmsg_queue.empty() && this->evse_enabled) || this->termination_requested;
+            });
+
+            if (this->termination_requested)
+                break;
+
+            // remove from queue
+            tmpctx.error_message = this->errmsg_queue.front();
+            this->errmsg_queue.pop();
+
+            is_active = cb_proto_errmsg_is_active(&tmpctx);
+            module = cb_proto_errmsg_get_module(&tmpctx);
+            reason = cb_proto_errmsg_get_reason(&tmpctx);
+            additional_data1 = cb_proto_errmsg_get_additional_data_1(&tmpctx);
+            additional_data2 = cb_proto_errmsg_get_additional_data_2(&tmpctx);
+            std::string module_str{cb_proto_errmsg_module_to_str(module)};
+            std::string reason_str{cb_proto_errmsg_reason_to_str(module, reason)};
+
+            this->on_errmsg(is_active, static_cast<unsigned int>(module), module_str, reason, reason_str,
+                            additional_data1, additional_data2);
+        }
+
+        EVLOG_debug << "Error Message Thread terminated";
+    });
+
     // launch processing of received frames
     this->rx_thread = std::thread([&]() {
         // used to detect changes
@@ -274,6 +316,15 @@ CbParsley::CbParsley() {
                 // temperature interface polls in regular intervals by itself
                 // but it also does not hurt
                 break;
+
+            case cb_uart_com::COM_ERROR_MESSAGE: {
+                this->ctx.error_message = payload;
+                // it is not necessary to wake-up the "normal" waiters
+                notify = false;
+                std::scoped_lock notify_lock(this->errmsg_mutex);
+                this->errmsg_queue.push(payload);
+                this->errmsg_cv.notify_one();
+            } break;
 
             case cb_uart_com::COM_FW_VERSION:
                 this->ctx.fw_version = payload;

--- a/modules/CbParsleyDriver/parsley/CbParsley.hpp
+++ b/modules/CbParsleyDriver/parsley/CbParsley.hpp
@@ -83,8 +83,8 @@ public:
     ///        The parameter is the latest state as reported by the safety controller.
     sigslot::signal<const enum cs_safestate_active&> on_safestate_active;
 
-    /// @brief Signal used to inform about received error message
-    ///        The parameter is filled with the data from the latest error message string.
+    /// @brief Signal emitted whenever an error message is received.
+    ///        The parameters are filled with the data from the latest error message.
     sigslot::signal<bool, unsigned int, const std::string&, unsigned int, const std::string&, unsigned int,
                     unsigned int>
         on_errmsg;

--- a/modules/CbParsleyDriver/parsley/CbParsley.hpp
+++ b/modules/CbParsleyDriver/parsley/CbParsley.hpp
@@ -83,6 +83,12 @@ public:
     ///        The parameter is the latest state as reported by the safety controller.
     sigslot::signal<const enum cs_safestate_active&> on_safestate_active;
 
+    /// @brief Signal used to inform about received error message
+    ///        The parameter is filled with the data from the latest error message string.
+    sigslot::signal<bool, unsigned int, const std::string&, unsigned int, const std::string&, unsigned int,
+                    unsigned int>
+        on_errmsg;
+
     /// @brief Return whether the safety controller detected an emergency state.
     bool is_emergency();
 
@@ -164,6 +170,18 @@ private:
 
     /// @brief Queue used to serialize changes of Charge State frame for notifying
     std::queue<uint64_t> charge_state_changes;
+
+    /// @brief Thread for pushing received error messages to higher layers.
+    std::thread errmsg_thread;
+
+    /// @brief Mutex to protect access to the `error_messages` queue.
+    std::mutex errmsg_mutex;
+
+    /// @brief Condition variables used to wait for updates on `error_messages`
+    std::condition_variable errmsg_cv;
+
+    /// @brief Queue used to serialize Error Message frames for notifying
+    std::queue<uint64_t> errmsg_queue;
 
     /// @brief Mutex to ensure that only one inquiry request is in-flight at the same time
     std::mutex inquiry_mutex;

--- a/modules/CbParsleyDriver/temperatures/cb_chargesom_temperaturesImpl.cpp
+++ b/modules/CbParsleyDriver/temperatures/cb_chargesom_temperaturesImpl.cpp
@@ -53,22 +53,39 @@ void cb_chargesom_temperaturesImpl::ready() {
 
                 if (flags & PT1000_CHARGING_STOPPED) {
                     if (!this->charging_abort_cause_reported[i]) {
-                        EVLOG_warning << t.identification.value() << " caused charging abort: " << std::fixed
-                                      << std::setprecision(1) << t.temperature << " °C";
+                        std::ostringstream errmsg;
+                        errmsg << t.identification.value() << " caused charging abort: " << std::fixed
+                               << std::setprecision(1) << t.temperature << " °C";
+                        EVLOG_error << errmsg.str();
+
+                        auto e = this->error_factory->create_error("cb_chargesom_temperatures/ChargingAbort",
+                                                                   t.identification.value(), errmsg.str(),
+                                                                   Everest::error::Severity::High);
+                        this->raise_error(e);
+
                         this->charging_abort_cause_reported[i] = true;
                     }
                 } else {
                     // we can just reset the flag here since we don't want to
                     // notify the user explicitly because the port was reset completely
                     if (this->charging_abort_cause_reported[i]) {
-                        EVLOG_warning << t.identification.value() << " charging abort flag reset";
+                        EVLOG_info << t.identification.value() << " charging abort flag reset";
+                        this->clear_error("cb_chargesom_temperatures/ChargingAbort", t.identification.value());
                         this->charging_abort_cause_reported[i] = false;
                     }
                 }
 
                 if (flags & PT1000_SELFTEST_FAILED) {
                     if (!this->selftest_failed_reported[i]) {
-                        EVLOG_error << "Self-test for " << t.identification.value() << " failed.";
+                        std::ostringstream errmsg;
+                        errmsg << "Self-test for " << t.identification.value() << " failed.";
+                        EVLOG_error << errmsg.str();
+
+                        auto e = this->error_factory->create_error("cb_chargesom_temperatures/SelftestFailed",
+                                                                   t.identification.value(), errmsg.str(),
+                                                                   Everest::error::Severity::High);
+                        this->raise_error(e);
+
                         this->selftest_failed_reported[i] = true;
                     }
                     // unsure whether the data is (still) valid at all, so don't forward it anymore
@@ -77,7 +94,8 @@ void cb_chargesom_temperaturesImpl::ready() {
                     // we can just reset the flag here since we don't want to
                     // notify the user explicitly because the port was reset completely
                     if (this->selftest_failed_reported[i]) {
-                        EVLOG_warning << t.identification.value() << " selftest failed flag reset";
+                        EVLOG_info << t.identification.value() << " selftest failed flag reset";
+                        this->clear_error("cb_chargesom_temperatures/SelftestFailed", t.identification.value());
                         this->selftest_failed_reported[i] = false;
                     }
                 }


### PR DESCRIPTION
This PR adds support for new upcoming/improved error reporting capabilities of the safety controller firmware.

It was tested so far only on CCY, but the approach for Charge SOM is identical.
