### PR TITLE
CbSystem: align with upstream changes

### DIFF
--- a/modules/CbSystem/CMakeLists.txt
+++ b/modules/CbSystem/CMakeLists.txt
@@ -12,16 +12,12 @@ ev_setup_cpp_module()
 pkg_search_module(LIBSYSTEMD REQUIRED libsystemd)
 target_link_libraries(${MODULE_NAME} PUBLIC ${LIBSYSTEMD_LIBRARIES})
 
-set (ADDITIONAL_MODULE_LIBS everest::timer)
-
-list(APPEND ADDITIONAL_MODULE_LIBS
-    date::date
-    date::date-tz
-)
-
 target_link_libraries(${MODULE_NAME}
     PRIVATE
-        ${ADDITIONAL_MODULE_LIBS}
+        date::date
+        date::date-tz
+        everest::timer
+        everest::run_application
 )
 # ev@bcc62523-e22b-41d7-ba2f-825b493a3c97:v1
 

--- a/modules/CbSystem/CbSystem.hpp
+++ b/modules/CbSystem/CbSystem.hpp
@@ -13,6 +13,9 @@
 // headers for provided interface implementations
 #include <generated/interfaces/system/Implementation.hpp>
 
+// headers for required interface implementations
+#include <generated/interfaces/kvs/Interface.hpp>
+
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
 // insert your custom include headers here
 // ev@4bf81b14-a215-475c-a1d3-0a484ae48918:v1
@@ -29,10 +32,12 @@ struct Conf {
 class CbSystem : public Everest::ModuleBase {
 public:
     CbSystem() = delete;
-    CbSystem(const ModuleInfo& info, std::unique_ptr<systemImplBase> p_main, Conf& config) :
-        ModuleBase(info), p_main(std::move(p_main)), config(config) {};
+    CbSystem(const ModuleInfo& info, std::unique_ptr<systemImplBase> p_main,
+             std::vector<std::unique_ptr<kvsIntf>> r_store, Conf& config) :
+        ModuleBase(info), p_main(std::move(p_main)), r_store(std::move(r_store)), config(config) {};
 
     const std::unique_ptr<systemImplBase> p_main;
+    const std::vector<std::unique_ptr<kvsIntf>> r_store;
     const Conf& config;
 
     // ev@1fce4c5e-0ab8-41bb-90f7-14277703d2ac:v1

--- a/modules/CbSystem/README.md
+++ b/modules/CbSystem/README.md
@@ -7,4 +7,23 @@ Currently this includes the following commands:
 *  Firmware Updates
 *  Setting of System time 
 
-Corresponding variables signal the state of Log Uploads and Firmware Updates
+Corresponding variables signal the state of Log Uploads and Firmware Updates.
+
+## Boot reason
+To be able to notify the system of the finalized firmware update state (as
+we rebooted before the update was successful), and that the boot reason was
+a successful firmware update, we place a "marker" file into a file system
+location which persists updates.  Its contents consist of the originally
+inactive partition name (the one which receives the update), and the update
+request ID.
+
+On start-up of the module, existence of this marker file is checked.  If it
+exists, a boot reason "FirmwareUpdate" is reported.  If we are running from
+its named partition (now the active one), a firmware update status
+"Installed" is reported.
+
+Additionally, we have storage of the boot reason in a persistant store
+module, which is optional.  This module can store the boot reason in a key
+"ocpp_boot_reason" as "FirmwareUpdate" or "RemoteReset".  If the persistent
+store is present, its value will be used for the boot reason, otherwise the
+value "FirmwareUpdate" from the marker file handling.

--- a/modules/CbSystem/main/systemImpl.cpp
+++ b/modules/CbSystem/main/systemImpl.cpp
@@ -132,9 +132,6 @@ static std::string get_partition(PartitionType part_type) {
 }
 
 void systemImpl::ready() {
-    // TODO: Remove this sleep when fix of the issues (ref: https://github.com/EVerest/libocpp/issues/758,
-    // https://github.com/EVerest/everest-core/issues/841) are implemented
-    sleep(20);
     check_update_marker();
 }
 

--- a/modules/CbSystem/main/systemImpl.cpp
+++ b/modules/CbSystem/main/systemImpl.cpp
@@ -792,12 +792,12 @@ types::system::BootReason systemImpl::handle_get_boot_reason() {
     }
     auto reason_variant = this->mod->r_store.at(0)->call_load(boot_reason_key);
     auto* reason = std::get_if<std::string>(&reason_variant);
-    std::string final_reason{boot_reason_to_string(this->boot_reason)}; // fallback: rauc-based
+    auto final_reason{this->boot_reason}; // fallback: rauc-based
     if (reason != nullptr) {
-        final_reason = *reason;
+        final_reason = types::system::string_to_boot_reason(*reason);
     }
     this->mod->r_store.at(0)->call_delete(boot_reason_key);
-    return types::system::string_to_boot_reason(final_reason);
+    return final_reason;
 }
 
 } // namespace main

--- a/modules/CbSystem/main/systemImpl.cpp
+++ b/modules/CbSystem/main/systemImpl.cpp
@@ -100,6 +100,7 @@ void systemImpl::init() {
     this->firmware_download_running = false;
     this->firmware_installation_running = false;
     this->standard_firmware_update_running = false;
+    this->boot_reason_key = "ocpp_boot_reason";
 
     if (fs::exists(MARKER_FILE_PATH)) {
         this->boot_reason = types::system::BootReason::FirmwareUpdate;
@@ -266,7 +267,7 @@ void systemImpl::standard_firmware_update(const types::system::FirmwareUpdateReq
         }
 
         while (firmware_status.firmware_update_status == types::system::FirmwareUpdateStatusEnum::DownloadFailed &&
-               retries <= total_retries) {
+               retries < total_retries) {
             boost::process::ipstream stream;
             boost::process::child cmd(firmware_updater.string(), boost::process::args(args),
                                       boost::process::std_out > stream);
@@ -278,8 +279,13 @@ void systemImpl::standard_firmware_update(const types::system::FirmwareUpdateReq
                 this->publish_firmware_update_status(firmware_status);
             }
             if (firmware_status.firmware_update_status == types::system::FirmwareUpdateStatusEnum::DownloadFailed &&
-                retries <= total_retries) {
+                retries < total_retries) {
                 std::this_thread::sleep_for(std::chrono::seconds(retry_interval));
+            }
+            if (firmware_status.firmware_update_status == types::system::FirmwareUpdateStatusEnum::Installed and
+                !this->mod->r_store.empty()) {
+                this->mod->r_store.at(0)->call_store(boot_reason_key,
+                                                     boot_reason_to_string(types::system::BootReason::FirmwareUpdate));
             }
             cmd.wait();
         }
@@ -425,7 +431,7 @@ void systemImpl::download_signed_firmware(const types::system::FirmwareUpdateReq
     firmware_status.firmware_update_status = firmware_status_enum;
 
     while (firmware_status.firmware_update_status == types::system::FirmwareUpdateStatusEnum::DownloadFailed &&
-           retries <= total_retries && !this->interrupt_firmware_download) {
+           retries < total_retries && !this->interrupt_firmware_download) {
         boost::process::ipstream download_stream;
         boost::process::child download_cmd(firmware_downloader.string(), boost::process::args(download_args),
                                            boost::process::std_out > download_stream);
@@ -441,7 +447,7 @@ void systemImpl::download_signed_firmware(const types::system::FirmwareUpdateReq
             download_cmd.terminate();
         }
         if (firmware_status.firmware_update_status == types::system::FirmwareUpdateStatusEnum::DownloadFailed &&
-            retries <= total_retries) {
+            retries < total_retries) {
             std::this_thread::sleep_for(std::chrono::seconds(retry_interval));
         }
     }
@@ -505,6 +511,16 @@ void systemImpl::install_signed_firmware(const types::system::FirmwareUpdateRequ
         while (std::getline(install_stream, temp)) {
             firmware_status.firmware_update_status = types::system::string_to_firmware_update_status_enum(temp);
             this->publish_firmware_update_status(firmware_status);
+        }
+        if (firmware_status.firmware_update_status == types::system::FirmwareUpdateStatusEnum::Installed) {
+            if (!this->mod->r_store.empty()) {
+                this->mod->r_store.at(0)->call_store(boot_reason_key,
+                                                     boot_reason_to_string(types::system::BootReason::FirmwareUpdate));
+            }
+
+            auto reset_type = types::system::ResetType::Hard;
+            bool firmware_installation_running_copy = this->firmware_installation_running;
+            this->handle_reset(reset_type, firmware_installation_running_copy);
         }
     } else {
         firmware_status.firmware_update_status = types::system::FirmwareUpdateStatusEnum::InstallationFailed;
@@ -667,7 +683,7 @@ systemImpl::handle_upload_logs(types::system::UploadLogsRequest& upload_logs_req
             upload_logs_request.retry_interval_s.value_or(this->mod->config.default_retry_interval);
 
         types::system::LogStatus log_status;
-        while (!uploaded && retries <= total_retries && !this->interrupt_log_upload) {
+        while (!uploaded && retries < total_retries && !this->interrupt_log_upload) {
 
             boost::process::ipstream stream;
             boost::process::child cmd(diagnostics_uploader.string(), boost::process::args(args),
@@ -694,7 +710,7 @@ systemImpl::handle_upload_logs(types::system::UploadLogsRequest& upload_logs_req
                 log_status.log_status = types::system::LogStatusEnum::AcceptedCanceled;
                 this->publish_log_status(log_status);
                 cmd.terminate();
-            } else if (log_status.log_status != types::system::LogStatusEnum::Uploaded && retries <= total_retries) {
+            } else if (log_status.log_status != types::system::LogStatusEnum::Uploaded && retries < total_retries) {
                 // command finished, but neither interrupted nor uploaded
                 std::this_thread::sleep_for(std::chrono::seconds(retry_interval));
             } else {
@@ -724,6 +740,10 @@ void systemImpl::handle_reset(types::system::ResetType& type, bool& scheduled) {
     // channels in parallel when this call returns
     std::thread([this, type, scheduled] {
         EVLOG_info << "Reset request received: " << type << ", " << (scheduled ? "" : "not ") << "scheduled";
+        if (!this->mod->r_store.empty() and !this->mod->r_store.at(0)->call_exists(boot_reason_key)) {
+            this->mod->r_store.at(0)->call_store(boot_reason_key,
+                                                 boot_reason_to_string(types::system::BootReason::RemoteReset));
+        }
 
         std::this_thread::sleep_for(std::chrono::seconds(this->mod->config.reset_delay));
 
@@ -766,7 +786,18 @@ bool systemImpl::handle_set_system_time(std::string& timestamp) {
 };
 
 types::system::BootReason systemImpl::handle_get_boot_reason() {
-    return this->boot_reason;
+    if (this->mod->r_store.empty()) {
+        // use our own rauc-based boot reason
+        return this->boot_reason;
+    }
+    auto reason_variant = this->mod->r_store.at(0)->call_load(boot_reason_key);
+    auto* reason = std::get_if<std::string>(&reason_variant);
+    std::string final_reason{boot_reason_to_string(this->boot_reason)}; // fallback: rauc-based
+    if (reason != nullptr) {
+        final_reason = *reason;
+    }
+    this->mod->r_store.at(0)->call_delete(boot_reason_key);
+    return types::system::string_to_boot_reason(final_reason);
 }
 
 } // namespace main

--- a/modules/CbSystem/main/systemImpl.cpp
+++ b/modules/CbSystem/main/systemImpl.cpp
@@ -15,7 +15,9 @@
 
 #include <utils/date.hpp>
 
-#include <boost/process.hpp>
+#include <everest/run_application/run_application.hpp>
+
+using namespace everest::run_application;
 
 namespace module {
 namespace main {
@@ -125,23 +127,8 @@ static std::string get_partition(PartitionType part_type) {
 
     const std::string shell_cmd = R"(rauc status | sed "s/$(printf '\033')\[[0-9;]*m//g" | awk '/rootfs\./ && /)" +
                                   rauc_status_search + R"(/ {gsub(/\[|\]/, "", $2); print $2}')";
-    boost::process::ipstream stream;
-    boost::process::child cmd(boost::process::search_path("sh"), std::vector<std::string> {"-c", shell_cmd},
-                              boost::process::std_out > stream);
-
-    std::string output;
-    // this is generic multi-line handling
-    // while (cmd.running() && std::getline(stream, line) && !line.empty()) {
-    //     output += line + "\n";
-    // }
-    // this is single-line handling
-    if (cmd.running()) {
-        std::getline(stream, output);
-    }
-
-    cmd.wait();
-
-    return output;
+    const CmdOutput cmd_output = run_application("sh", std::vector<std::string> {"-c", shell_cmd});
+    return cmd_output.output;
 }
 
 void systemImpl::ready() {
@@ -268,16 +255,14 @@ void systemImpl::standard_firmware_update(const types::system::FirmwareUpdateReq
 
         while (firmware_status.firmware_update_status == types::system::FirmwareUpdateStatusEnum::DownloadFailed &&
                retries < total_retries) {
-            boost::process::ipstream stream;
-            boost::process::child cmd(firmware_updater.string(), boost::process::args(args),
-                                      boost::process::std_out > stream);
-            std::string temp;
             retries += 1;
-            while (std::getline(stream, temp)) {
-                EVLOG_info << "Firmware update status: " << temp;
-                firmware_status.firmware_update_status = types::system::string_to_firmware_update_status_enum(temp);
-                this->publish_firmware_update_status(firmware_status);
-            }
+            run_application(firmware_updater.string(), args, [this, &firmware_status](const std::string& output_line) {
+                EVLOG_info << "Firmware update status: " << output_line;
+                firmware_status.firmware_update_status =
+                    types::system::string_to_firmware_update_status_enum(output_line);
+                 this->publish_firmware_update_status(firmware_status);
+                return CmdControl::Continue;
+            });
             if (firmware_status.firmware_update_status == types::system::FirmwareUpdateStatusEnum::DownloadFailed &&
                 retries < total_retries) {
                 std::this_thread::sleep_for(std::chrono::seconds(retry_interval));
@@ -287,14 +272,13 @@ void systemImpl::standard_firmware_update(const types::system::FirmwareUpdateReq
                 this->mod->r_store.at(0)->call_store(BOOT_REASON_KEY,
                                                      boot_reason_to_string(types::system::BootReason::FirmwareUpdate));
             }
-            cmd.wait();
         }
         this->standard_firmware_update_running = false;
         if (firmware_status.firmware_update_status == types::system::FirmwareUpdateStatusEnum::InstallRebooting) {
             EVLOG_warning << "Firmware update finished successfully. Initiating reboot in 5 seconds";
             std::this_thread::sleep_for(std::chrono::seconds(5));
             EVLOG_info << "Rebooting...";
-            boost::process::system("reboot");
+            run_application("reboot", {});
         } else if ((firmware_status.firmware_update_status ==
                     types::system::FirmwareUpdateStatusEnum::DownloadFailed) ||
                    (firmware_status.firmware_update_status ==
@@ -432,20 +416,19 @@ void systemImpl::download_signed_firmware(const types::system::FirmwareUpdateReq
 
     while (firmware_status.firmware_update_status == types::system::FirmwareUpdateStatusEnum::DownloadFailed &&
            retries < total_retries && !this->interrupt_firmware_download) {
-        boost::process::ipstream download_stream;
-        boost::process::child download_cmd(firmware_downloader.string(), boost::process::args(download_args),
-                                           boost::process::std_out > download_stream);
-        std::string temp;
+        run_application(
+            firmware_downloader.string(), download_args, [this, &firmware_status](const std::string& output_line) {
+                firmware_status.firmware_update_status =
+                    types::system::string_to_firmware_update_status_enum(output_line);
+                this->publish_firmware_update_status(firmware_status);
+                if (this->interrupt_firmware_download) {
+                    EVLOG_info << "Updating firmware was interrupted, terminating firmware update script, requestId: "
+                               << firmware_status.request_id;
+                    return CmdControl::Terminate;
+                }
+                return CmdControl::Continue;
+            });
         retries += 1;
-        while (std::getline(download_stream, temp) && !this->interrupt_firmware_download) {
-            firmware_status.firmware_update_status = types::system::string_to_firmware_update_status_enum(temp);
-            this->publish_firmware_update_status(firmware_status);
-        }
-        if (this->interrupt_firmware_download) {
-            EVLOG_info << "Updating firmware was interrupted, terminating firmware update script, requestId: "
-                       << firmware_status.request_id;
-            download_cmd.terminate();
-        }
         if (firmware_status.firmware_update_status == types::system::FirmwareUpdateStatusEnum::DownloadFailed &&
             retries < total_retries) {
             std::this_thread::sleep_for(std::chrono::seconds(retry_interval));
@@ -501,17 +484,16 @@ void systemImpl::install_signed_firmware(const types::system::FirmwareUpdateRequ
 
     if (!this->firmware_installation_running) {
         this->firmware_installation_running = true;
-        boost::process::ipstream install_stream;
         const auto firmware_installer = this->scripts_path / SIGNED_FIRMWARE_INSTALLER;
         const auto constants = this->scripts_path / CONSTANTS;
         const std::vector<std::string> install_args = {constants.string(), firmware_file_path.string()};
-        boost::process::child install_cmd(firmware_installer.string(), boost::process::args(install_args),
-                                          boost::process::std_out > install_stream);
-        std::string temp;
-        while (std::getline(install_stream, temp)) {
-            firmware_status.firmware_update_status = types::system::string_to_firmware_update_status_enum(temp);
-            this->publish_firmware_update_status(firmware_status);
-        }
+        run_application(firmware_installer.string(), install_args,
+                        [this, &firmware_status](const std::string& output_line) {
+                            firmware_status.firmware_update_status =
+                                types::system::string_to_firmware_update_status_enum(output_line);
+                            this->publish_firmware_update_status(firmware_status);
+                            return CmdControl::Continue;
+                        });
         if (firmware_status.firmware_update_status == types::system::FirmwareUpdateStatusEnum::Installed) {
             if (!this->mod->r_store.empty()) {
                 this->mod->r_store.at(0)->call_store(BOOT_REASON_KEY,
@@ -532,7 +514,7 @@ void systemImpl::install_signed_firmware(const types::system::FirmwareUpdateRequ
         EVLOG_warning << "Secure firmware update finished successfully. Initiating reboot in 5 seconds";
         std::this_thread::sleep_for(std::chrono::seconds(5));
         EVLOG_info << "Rebooting...";
-        boost::process::system("reboot");
+        run_application("reboot", {});
     } else if (firmware_status.firmware_update_status == types::system::FirmwareUpdateStatusEnum::InstallationFailed) {
         fs::remove(MARKER_FILE_PATH);
     }
@@ -684,39 +666,36 @@ systemImpl::handle_upload_logs(types::system::UploadLogsRequest& upload_logs_req
 
         types::system::LogStatus log_status;
         while (!uploaded && retries < total_retries && !this->interrupt_log_upload) {
-
-            boost::process::ipstream stream;
-            boost::process::child cmd(diagnostics_uploader.string(), boost::process::args(args),
-                                      boost::process::std_out > stream);
-            std::string temp;
             retries += 1;
             log_status.request_id = upload_logs_request.request_id.value_or(-1);
-            while (std::getline(stream, temp) && !this->interrupt_log_upload) {
-                if (temp == "Uploaded") {
-                    log_status.log_status = types::system::string_to_log_status_enum(temp);
-                } else if (temp == "UploadFailure" || temp == "PermissionDenied" || temp == "BadMessage" ||
-                           temp == "NotSupportedOperation") {
+            run_application(diagnostics_uploader.string(), args, [this, &log_status](const std::string& output_line) {
+                if (output_line == "Uploaded") {
+                    log_status.log_status = types::system::string_to_log_status_enum(output_line);
+                } else if (output_line == "UploadFailure" || output_line == "PermissionDenied" ||
+                           output_line == "BadMessage" || output_line == "NotSupportedOperation") {
                     log_status.log_status = types::system::LogStatusEnum::UploadFailure;
                 } else {
                     log_status.log_status = types::system::LogStatusEnum::Uploading;
                 }
-                EVLOG_info << "Log upload status: " << temp;
+                EVLOG_info << "Log upload status: " << output_line;
                 this->publish_log_status(log_status);
-            }
+                if (this->interrupt_log_upload) {
+                    return CmdControl::Terminate;
+                }
+                return CmdControl::Continue;
+            });
             if (this->interrupt_log_upload) {
                 EVLOG_info << "Uploading Logs was interrupted, terminating upload script, requestId: "
                            << log_status.request_id;
                 // N01.FR.20
                 log_status.log_status = types::system::LogStatusEnum::AcceptedCanceled;
                 this->publish_log_status(log_status);
-                cmd.terminate();
             } else if (log_status.log_status != types::system::LogStatusEnum::Uploaded && retries < total_retries) {
                 // command finished, but neither interrupted nor uploaded
                 std::this_thread::sleep_for(std::chrono::seconds(retry_interval));
             } else {
                 uploaded = true;
             }
-            cmd.wait();
         }
         this->log_upload_running = false;
         this->log_upload_cv.notify_one();
@@ -752,7 +731,7 @@ void systemImpl::handle_reset(types::system::ResetType& type, bool& scheduled) {
             kill(getpid(), SIGINT);
         } else {
             EVLOG_info << "Performing hard reset. Rebooting...";
-            boost::process::system("reboot");
+            run_application("reboot", {});
         }
     }).detach();
 }

--- a/modules/CbSystem/main/systemImpl.hpp
+++ b/modules/CbSystem/main/systemImpl.hpp
@@ -85,8 +85,6 @@ private:
     Everest::SteadyTimer signed_firmware_update_download_timer;
     Everest::SteadyTimer signed_firmware_update_install_timer;
 
-    std::string boot_reason_key;
-
     /**
      * @brief Executes a standard firmware update using the given \p firmware_update_request
      *

--- a/modules/CbSystem/main/systemImpl.hpp
+++ b/modules/CbSystem/main/systemImpl.hpp
@@ -69,7 +69,7 @@ private:
     bool log_upload_running {false};
     bool standard_firmware_update_running {false};
     bool firmware_download_running {false};
-    bool firmware_installation_running {false};
+    std::atomic<bool> firmware_installation_running {false};
     types::system::BootReason boot_reason {types::system::BootReason::PowerUp};
 
     std::condition_variable log_upload_cv;
@@ -84,6 +84,8 @@ private:
     Everest::SteadyTimer standard_update_firmware_timer;
     Everest::SteadyTimer signed_firmware_update_download_timer;
     Everest::SteadyTimer signed_firmware_update_install_timer;
+
+    std::string boot_reason_key;
 
     /**
      * @brief Executes a standard firmware update using the given \p firmware_update_request

--- a/modules/CbSystem/manifest.yaml
+++ b/modules/CbSystem/manifest.yaml
@@ -34,7 +34,6 @@ requires:
     interface: kvs
     min_connections: 0
     max_connections: 1
-enable_external_mqtt: false
 metadata:
   license: https://opensource.org/licenses/Apache-2.0
   authors:

--- a/modules/CbSystem/manifest.yaml
+++ b/modules/CbSystem/manifest.yaml
@@ -29,7 +29,11 @@ provides:
   main:
     description: Implements the system interface
     interface: system
-requires: {}
+requires:
+  store:
+    interface: kvs
+    min_connections: 0
+    max_connections: 1
 enable_external_mqtt: false
 metadata:
   license: https://opensource.org/licenses/Apache-2.0


### PR DESCRIPTION
This brings CbSystem in line with changes in the upstream System module.

- Fix number of retries.
- Change execution of programs from boost::process to everest::run_application.
- Track boot reason in (optional) persistent store.

This should also fix OCPP's reporting of BootNotificationRequest.reason RemoteReset.