### PR TITLE
CbSystem: use SIGTERM instead of SIGINT for system reset

### DIFF
--- a/modules/CbSystem/main/systemImpl.cpp
+++ b/modules/CbSystem/main/systemImpl.cpp
@@ -746,7 +746,7 @@ void systemImpl::handle_reset(types::system::ResetType& type, bool& scheduled) {
 
         if (type == types::system::ResetType::Soft) {
             EVLOG_info << "Performing soft reset now.";
-            kill(getpid(), SIGINT);
+            kill(getpid(), SIGTERM);
         } else {
             EVLOG_info << "Performing hard reset. Rebooting...";
             run_application("reboot", {});


### PR DESCRIPTION
This is a backport/cherry-pick of https://github.com/EVerest/EVerest/pull/2549 to our system module implementation.

The original PR description is:

Since d187e97 (PR #2048), the manager blocks SIGINT via sigprocmask to poll them through a signalfd, and forked module processes inherit that mask. The child-side fork code only unblocks SIGTERM and SIGCHLD; SIGINT is kept blocked.

Consequence: kill(getpid(), SIGINT) in a module no longer terminates it; the signal just sits pending forever, so handle_reset had become a silent no-op.